### PR TITLE
Andrewrutter/kkb 28 get events backend

### DIFF
--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -1,7 +1,6 @@
 import mongoDB from "../index";
 import EventSchema from "../models/Event";
 import { Event } from "utils/types";
-import { mongo } from "mongoose";
 
 /**
  * @param id EventId string to identify an event in our database.

--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -1,6 +1,7 @@
 import mongoDB from "../index";
 import EventSchema from "../models/Event";
 import { Event } from "utils/types";
+import { mongo } from "mongoose";
 
 /**
  * @param id EventId string to identify an event in our database.
@@ -18,6 +19,20 @@ export const getEvent = async function (id: string) {
     }
 
     return event;
+};
+
+/**
+ * @returns All events.
+ */
+export const getEvents = async function () {
+    await mongoDB();
+
+    const events = (await EventSchema.find({})) as Array<Event>;
+    if (events == null) {
+        throw new Error("No events");
+    }
+
+    return events;
 };
 
 /**

--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -27,7 +27,7 @@ export const getEvents = async function () {
     await mongoDB();
 
     const events = (await EventSchema.find({})) as Array<Event>;
-    if (events == null) {
+    if (!events || !events.length) {
         throw new Error("No events");
     }
 

--- a/src/pages/api/events/index.ts
+++ b/src/pages/api/events/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import errors from "utils/errors";
 import formidable from "formidable";
 import { Event } from "utils/types";
-import { addEvent } from "server/actions/Event";
+import { addEvent, getEvents } from "server/actions/Event";
 
 // formidable config
 export const config = {
@@ -16,7 +16,12 @@ export const config = {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (req.method === "GET") {
-            throw new Error("Not implemented yet!");
+            const events: Array<Event> = await getEvents();
+
+            res.status(200).json({
+                success: true,
+                payload: { events },
+            });
         } else if (req.method === "POST") {
             const form = new formidable.IncomingForm();
             form.parse(req, async (err: string, fields: formidable.Fields, files: formidable.Files) => {

--- a/tst/server/Event.test.ts
+++ b/tst/server/Event.test.ts
@@ -1,4 +1,4 @@
-import { getEvent, addEvent } from "server/actions/Event";
+import { getEvent, getEvents, addEvent } from "server/actions/Event";
 import EventSchema from "server/models/Event";
 import { Event } from "utils/types";
 
@@ -29,6 +29,24 @@ describe("getEvent() tests", () => {
         //mock EventSchema.findById to return mockEvent, which will then throw an error
         EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
         await expect(getEvent("602734007d7de15fae321152")).rejects.toThrowError("Event does not exist");
+    });
+});
+
+describe("getEvents() tests", () => {
+    test("events exist", async () => {
+        const mockEvents = [{ name: "test1" }, { name: "test2" }];
+
+        EventSchema.find = jest.fn().mockResolvedValue(mockEvents);
+        await expect(getEvents()).resolves.toEqual(mockEvents);
+    });
+
+    test("no events exist", async () => {
+        expect.assertions(1);
+
+        const mockEvents = undefined;
+
+        EventSchema.find = jest.fn().mockResolvedValue(mockEvents);
+        await expect(getEvents()).rejects.toThrowError("No events");
     });
 });
 


### PR DESCRIPTION
Very similar to PR#13, [KKB-33-get-event](https://github.com/hack4impact-utk/keep-knox-beautiful/tree/kemalfidan/KKB-33-get-event), except it returns ALL events in the database. Code is almost the same, but the `getEvents()` function uses `.find({})` instead of `.findById(id)` to return all the events in the DB in an array, which will eventually be paginated. 

Below is testing using postman and a web browser on dummy data in the DB. Actual DB contents in compass are on the right. Also added unit tests.
![postman](https://user-images.githubusercontent.com/71574118/108582209-a8d9b900-72ff-11eb-907b-d0d4aacafc3b.png)
![localhost](https://user-images.githubusercontent.com/71574118/108582214-b98a2f00-72ff-11eb-853e-43a9c60f4e9e.png)
