### PR TITLE
Andrewrutter/kkb 38 delete event backend

### DIFF
--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -45,3 +45,15 @@ export const addEvent = async function (event: Event) {
 
     await EventSchema.create(event);
 };
+
+/**
+ * @param id EventId of event that will be deleted
+ */
+export const deleteEvent = async function (id: string) {
+    await mongoDB();
+    if (!id || id == "") {
+        throw new Error("Invalid id");
+    }
+
+    await EventSchema.findByIdAndDelete(id);
+};

--- a/src/pages/api/events/[eventId]/index.ts
+++ b/src/pages/api/events/[eventId]/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { getEvent } from "server/actions/Event";
+import { getEvent, deleteEvent } from "server/actions/Event";
 import errors from "utils/errors";
 import { Event } from "utils/types";
 
@@ -7,19 +7,30 @@ import { Event } from "utils/types";
 // DELETE /api/events/[eventId] will delete event eventId - Private
 // POST /api/events/[eventId] will update event eventId with form data - Private
 
-// @route   GET /api/events/[eventId] - Returns a single Event object for event eventId. - Public
+// @route   GET /api/event/[eventId] - Returns a single Event object for event eventId. - Public
+// @route   DELETE /api/event/[eventId] - Deletes single Event object event eventId.
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (!req || !req.query || !req.query.eventId) {
             throw new Error("Need an event id for this route.");
         }
 
-        const id = req.query.eventId as string;
-        const event: Event = await getEvent(id);
-        res.status(200).json({
-            success: true,
-            payload: event,
-        });
+        if (req.method == "GET") {
+            const id = req.query.eventId as string;
+            const event: Event = await getEvent(id);
+            res.status(200).json({
+                success: true,
+                payload: event,
+            });
+        }
+
+        if (req.method == "DELETE") {
+            const id = req.query.eventId as string;
+            await deleteEvent(id);
+            res.status(200).json({
+                success: true,
+            });
+        }
     } catch (error) {
         console.error(error instanceof Error && error);
         res.status(400).json({

--- a/tst/server/Event.test.ts
+++ b/tst/server/Event.test.ts
@@ -71,3 +71,38 @@ describe("addEvent() tests", () => {
         expect(EventSchema.create).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("deleteEvent() tests", () => {
+    test("valid event", async () => {
+        const mockEvent = {
+            name: "test",
+        };
+
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        await expect(getEvent("602734007d7de15fae321153")).resolves.toEqual(mockEvent);
+    });
+
+    test("invalid parameters", async () => {
+        expect.assertions(1);
+        await expect(getEvent("")).rejects.toThrowError("Invalid id");
+    });
+
+    test("no event with that id", async () => {
+        expect.assertions(1);
+        // mongoose returns undefined when a query results in no results
+        const mockEvent = undefined;
+
+        //mock EventSchema.findById to return mockEvent, which will then throw an error
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        await expect(getEvent("602734007d7de15fae321152")).rejects.toThrowError("Event does not exist");
+    });
+
+    test("event deleted", async () => {
+        const mockEvent = {
+            name: "test",
+        };
+
+        EventSchema.findByIdAndDelete = jest.fn().mockResolvedValue(mockEvent);
+        await expect(getEvent("602734007d7de15fae321152")).rejects.toThrowError("Event does not exist");
+    });
+});

--- a/tst/server/Event.test.ts
+++ b/tst/server/Event.test.ts
@@ -1,4 +1,5 @@
-import { getEvent, getEvents, addEvent } from "server/actions/Event";
+import { ObjectId } from "mongodb";
+import { getEvent, getEvents, addEvent, deleteEvent } from "server/actions/Event";
 import EventSchema from "server/models/Event";
 import { Event } from "utils/types";
 
@@ -73,28 +74,9 @@ describe("addEvent() tests", () => {
 });
 
 describe("deleteEvent() tests", () => {
-    test("valid event", async () => {
-        const mockEvent = {
-            name: "test",
-        };
-
-        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
-        await expect(getEvent("602734007d7de15fae321153")).resolves.toEqual(mockEvent);
-    });
-
     test("invalid parameters", async () => {
         expect.assertions(1);
-        await expect(getEvent("")).rejects.toThrowError("Invalid id");
-    });
-
-    test("no event with that id", async () => {
-        expect.assertions(1);
-        // mongoose returns undefined when a query results in no results
-        const mockEvent = undefined;
-
-        //mock EventSchema.findById to return mockEvent, which will then throw an error
-        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
-        await expect(getEvent("602734007d7de15fae321152")).rejects.toThrowError("Event does not exist");
+        await expect(deleteEvent("")).rejects.toThrowError("Invalid id");
     });
 
     test("event deleted", async () => {
@@ -102,7 +84,9 @@ describe("deleteEvent() tests", () => {
             name: "test",
         };
 
-        EventSchema.findByIdAndDelete = jest.fn().mockResolvedValue(mockEvent);
-        await expect(getEvent("602734007d7de15fae321152")).rejects.toThrowError("Event does not exist");
+        EventSchema.findByIdAndDelete = jest.fn().mockImplementation(async (event: Event) => event);
+        await deleteEvent("testid123");
+        expect(EventSchema.findByIdAndDelete).lastCalledWith("testid123");
+        expect(EventSchema.findByIdAndDelete).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Created `deleteEvent()` function — which takes an ID as a parameter and deletes the corresponding event from the db — the api route for it, and tests. Tested in postman creating an entry in the db and sending `localhost:3000/api/events/[eventId]` with the `DELETE` method, which successfully removed that entry from the db. 
I am a little shaky on the tests, so if you could look at those with a bit more scrutiny than usual, it would be much appreciated!

Also, the `deleteEvent()` function simply returns the payload `success: true` and nothing else, so if you'd like something else in there, like a confirmation message, or the ID of the deleted entry, please let me know. 