### PR TITLE
Event description page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@material-ui/core": "^4.11.3",
+        "@material-ui/icons": "^4.11.2",
         "@types/formidable": "^1.0.32",
         "@types/mongoose": "^5.10.3",
         "formidable": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "@material-ui/icons": "^4.11.2",
         "@types/formidable": "^1.0.32",
         "@types/mongoose": "^5.10.3",
+        "date-fns": "^2.0.0-beta.5",
         "formidable": "^1.2.2",
         "mongodb": "^3.6.4",
         "mongoose": "^5.11.15",

--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -9,31 +9,39 @@ export const EventSchema = new Schema({
     },
     description: {
         type: String,
-        required: true,
+        required: false,
     },
-    start_time: {
-        type: Date,
-        required: true,
+    caption: {
+        type: String,
+        required: false,
     },
-    end_time: {
-        type: Date,
-        required: true,
+    maxVolunteers: {
+        type: Number,
+        required: false,
     },
-    start_registration: {
+    startDate: {
         type: Date,
         required: false,
     },
-    end_registration: {
+    endDate: {
+        type: Date,
+        required: false,
+    },
+    startRegistration: {
+        type: Date,
+        required: false,
+    },
+    endRegistration: {
         type: Date,
         required: false,
     },
     location: {
         type: String,
-        required: true,
+        required: false,
     },
     hours: {
         type: String,
-        required: true,
+        required: false,
     },
     image: {
         type: ContentfulImageSchema,

--- a/src/components/DummyDate/index.tsx
+++ b/src/components/DummyDate/index.tsx
@@ -31,6 +31,19 @@ export default function DateAndTimePickers() {
             <CoreTypography variant="h1">{`${constants.org.name.full} events`}</CoreTypography>
             <form className={classes.container} noValidate>
                 <TextField
+                    id="datetime-local"
+                    label="Event Start"
+                    type="datetime-local"
+                    defaultValue="2021-05-24T10:30"
+                    className={classes.textField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    onChange={printDate}
+                />
+            </form>
+            {/* <form className={classes.container} noValidate>
+                <TextField
                     id="date-local"
                     label="Event Start"
                     type="date"
@@ -42,6 +55,20 @@ export default function DateAndTimePickers() {
                     onChange={printDate}
                 />
             </form>
+            <form className={classes.container} noValidate>
+                <TextField
+                    id="time-local"
+                    label="Event Start"
+                    type="time"
+                    defaultValue="10:30"
+                    className={classes.textField}
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    onChange={printDate}
+                />
+            </form> */}
+
         </>
     );
 }

--- a/src/components/DummyDate/index.tsx
+++ b/src/components/DummyDate/index.tsx
@@ -68,7 +68,6 @@ export default function DateAndTimePickers() {
                     onChange={printDate}
                 />
             </form> */}
-
         </>
     );
 }

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -9,12 +9,15 @@ const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         container: {
             backgroundColor: theme.palette.primary.main,
-            height: "120px",
-            display: "flex",
-            alignItems: "center",
         },
         wrapper: {
-            height: "80px",
+            display: "flex",
+            alignItems: "center",
+            paddingTop: "10px",
+            paddingBottom: "10px",
+            paddingLeft: "0px",
+        },
+        textWrapper: {
             textAlign: "center",
             color: colors.white,
         },
@@ -30,17 +33,21 @@ export default function Footer() {
     return (
         <React.Fragment>
             <Container maxWidth="xl" className={styles.container}>
-                <img src={`/${constants.org.images.logo}`} width="80px" alt={`${constants.org.name.short} logo`}></img>
                 <Container maxWidth="xl" className={styles.wrapper}>
-                    <CoreTypography variant="h4"> {constants.org.footer.address} </CoreTypography>
-                    <CoreTypography variant="h4">
-                        {" "}
-                        {`${constants.org.footer.phone} ${constants.org.footer.email}`}{" "}
-                    </CoreTypography>
-                    <CoreTypography variant="h4" className={styles.lastText}>
-                        {" "}
-                        created by hack4impact utk{" "}
-                    </CoreTypography>
+                    <img
+                        src={`/${constants.org.images.logo}`}
+                        width="80px"
+                        alt={`${constants.org.name.short} logo`}
+                    ></img>
+                    <Container maxWidth="xl" className={styles.textWrapper}>
+                        <CoreTypography variant="h4"> {constants.org.footer.address} </CoreTypography>
+                        <CoreTypography variant="h4">
+                            {`${constants.org.footer.phone} ${constants.org.footer.email}`}
+                        </CoreTypography>
+                        <CoreTypography variant="h4" className={styles.lastText}>
+                            created by hack4impact utk
+                        </CoreTypography>
+                    </Container>
                 </Container>
             </Container>
         </React.Fragment>

--- a/src/components/core/typography/CoreTypography.tsx
+++ b/src/components/core/typography/CoreTypography.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Typography } from "@material-ui/core";
 import { TypographyStyleOptions } from "@material-ui/core/styles/createTypography";
 
-type Variant = "h1" | "h2" | "h3" | "h4" | "h5" | "body1" | "body2" | "overline" | "caption";
+type Variant = "h1" | "h2" | "h3" | "h4" | "h5" | "body1" | "body2" | "overline" | "caption" | "subtitle1";
 
 export const typographyStyles: Readonly<Record<Variant, TypographyStyleOptions>> = {
     h1: {
@@ -83,6 +83,14 @@ export const typographyStyles: Readonly<Record<Variant, TypographyStyleOptions>>
         lineHeight: "130%",
         letterSpacing: "normal",
     },
+    subtitle1: {
+        fontFamily: "Roboto",
+        fontWeight: "normal",
+        fontSize: "0.70rem",
+        fontStyle: "normal",
+        lineHeight: "125%",
+        letterSpacing: "normal",
+    }
 };
 
 type Props = Omit<React.ComponentProps<typeof Typography>, "variant"> & {

--- a/src/components/core/typography/CoreTypography.tsx
+++ b/src/components/core/typography/CoreTypography.tsx
@@ -90,7 +90,7 @@ export const typographyStyles: Readonly<Record<Variant, TypographyStyleOptions>>
         fontStyle: "normal",
         lineHeight: "125%",
         letterSpacing: "normal",
-    }
+    },
 };
 
 type Props = Omit<React.ComponentProps<typeof Typography>, "variant"> & {

--- a/src/components/core/typography/CoreTypography.tsx
+++ b/src/components/core/typography/CoreTypography.tsx
@@ -8,7 +8,7 @@ export const typographyStyles: Readonly<Record<Variant, TypographyStyleOptions>>
     h1: {
         fontFamily: "Ubuntu",
         fontWeight: 800,
-        fontSize: "2.25rem",
+        fontSize: "3.5rem",
         fontStyle: "normal",
         fontFeatureSettings: "'liga' off",
         lineHeight: "150%",
@@ -17,7 +17,7 @@ export const typographyStyles: Readonly<Record<Variant, TypographyStyleOptions>>
     h2: {
         fontFamily: "Ubuntu",
         fontWeight: 800,
-        fontSize: "1.5rem",
+        fontSize: "2.25rem",
         fontStyle: "normal",
         fontFeatureSettings: "'liga' off",
         lineHeight: "140%",

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -3,13 +3,17 @@ import Footer from "src/components/Footer";
 import { getEvent } from "server/actions/Event";
 import { Event } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";
-import constants from "utils/constants";
-import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import Error from "next/error";
+import constants from "utils/constants";
 import CoreTypography from "src/components/core/typography/CoreTypography";
-import Paper from "@material-ui/core/Paper";
-import Container from "@material-ui/core/Container";
 import colors from "src/components/core/colors";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import Paper from "@material-ui/core/Paper";
+import Card from "@material-ui/core/Card";
+import Container from "@material-ui/core/Container";
+import CardContent from '@material-ui/core/CardContent';
+import ScheduleIcon from '@material-ui/icons/Schedule';
+import LocationOnIcon from '@material-ui/icons/LocationOn';
 
 interface Props {
     event: Event;
@@ -54,8 +58,8 @@ const useStyles = makeStyles((theme: Theme) =>
             flexDirection: "column",
             // justifyContent: "center",
         },
-        paper: {
-            width: "150px",
+        card: {
+            width: "160px",
             height: "120px",
             margin: "20px",
             marginRight: "30px",
@@ -66,7 +70,19 @@ const useStyles = makeStyles((theme: Theme) =>
             width: "500px",
             padding: "20px",
         },
-
+        cardTitle: {
+            display: "flex",
+            alignItems: "center",
+        },
+        titleName: {
+            color: theme.palette.accent.main,
+        },
+        titleIcon: {
+            marginRight: "5px",
+        },
+        cardText: {
+            marginTop: "15px",
+        }
     })
 );
 
@@ -76,6 +92,16 @@ const EventPage: NextPage<Props> = ({ event }) => {
     if (!event) {
         return <Error statusCode={404} />;
     }
+
+
+    const getTime = () => {
+        return (
+            <div>
+                Tue, September 20, 2021 10:00 AM - 12:00 PM
+            </div>
+        );
+    }
+
 
     return (
         <>
@@ -92,17 +118,41 @@ const EventPage: NextPage<Props> = ({ event }) => {
                 {/* <Container maxWidth="md" style={{backgroundColor: "blue"}}>test</Container>
                 <Container maxWidth="sm">test</Container> */}
                 <div className={styles.dateContainer}>
-                    <Paper className={styles.paper}></Paper>
-                    <Paper className={styles.paper}></Paper>
+                    <Card className={styles.card}>
+                        <CardContent>
+                            <div className={styles.cardTitle}>
+                                <ScheduleIcon className={styles.titleIcon}/>
+                                <CoreTypography variant="h5" className={styles.titleName}>
+                                    Event Time
+                                </CoreTypography>
+                            </div>
+                            <CoreTypography variant="subtitle1" className={styles.cardText}>
+                                {getTime()}
+                            </CoreTypography>
+                        </CardContent>
+                    </Card>
+                    <Card className={styles.card}>
+                        <CardContent>
+                            <div className={styles.cardTitle}>
+                                <LocationOnIcon className={styles.titleIcon}/>
+                                <CoreTypography variant="h5" className={styles.titleName}>
+                                    Location
+                                </CoreTypography>
+                            </div>
+                            <CoreTypography variant="subtitle1" className={styles.cardText}>
+                                {event.location}
+                            </CoreTypography>
+                        </CardContent>
+                    </Card>
                 </div>
                 <div className={styles.descContainer}>
                     <CoreTypography variant="body2">
                         Join us on the third Saturday of each month for a Saturday Spruce Up.
-                        Each month's location and activity will change. <br /> <br />
+                        Each month's location and activity will change. <br/> <br/>
                         This month we will be heading to Danny Mayfield Park in Mechanicsville. 
-                        We will meet at the park pavilion, across from Maynard Elementary. Parking is located along the street. <br /> <br />
-                        Pre-registration is required. Sign ups will close on February 18, 2021. <br /> <br />
-                        All supplies will be provided. Please wear closed-toed shoes and bring water. <br /> <br />
+                        We will meet at the park pavilion, across from Maynard Elementary. Parking is located along the street. <br/> <br/>
+                        Pre-registration is required. Sign ups will close on February 18, 2021. <br/> <br/>
+                        All supplies will be provided. Please wear closed-toed shoes and bring water. <br/> <br/>
                         COVID policies: please wear a mask during supplies distribution and safety instruction. Pre-registration is required.
                     </CoreTypography>
                 </div>

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -8,9 +8,7 @@ import constants from "utils/constants";
 import CoreTypography from "src/components/core/typography/CoreTypography";
 import colors from "src/components/core/colors";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
-import Paper from "@material-ui/core/Paper";
 import Card from "@material-ui/core/Card";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
 import Container from "@material-ui/core/Container";
 import CardContent from "@material-ui/core/CardContent";
 import ScheduleIcon from "@material-ui/icons/Schedule";
@@ -99,8 +97,6 @@ const EventPage: NextPage<Props> = ({ event }) => {
     }
     event.startDate = new Date(event.startDate as Date);
     event.endDate = new Date(event.endDate as Date);
-    //TODO remove addDays, adding 2 days to test diff dates
-    // event.endDate = addDays(new Date(event.endDate as Date), 2);
 
     // slightly diff display between events on the same day vs diff days
     const getTime = () => {

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -6,17 +6,72 @@ import { GetStaticPropsContext, NextPage } from "next";
 import constants from "utils/constants";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import Error from "next/error";
-import errors from "utils/errors";
 import CoreTypography from "src/components/core/typography/CoreTypography";
+import Paper from "@material-ui/core/Paper";
+import Container from "@material-ui/core/Container";
+import colors from "src/components/core/colors";
 
 interface Props {
     event: Event;
 }
 
-const useStyles = makeStyles((theme: Theme) => createStyles({}));
+const useStyles = makeStyles((theme: Theme) => 
+    createStyles({
+        eventHeader: {
+            backgroundColor: theme.palette.primary.main,
+            textAlign: "center",
+            height: "200px",
+            color: colors.white,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",          
+        },
+        logo: {
+            width: "80px",
+            marginRight: "20px"
+        },
+        eventName: {
+            textAlign: "center",
+            height: "110px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",          
+        },
+        caption: {
+            marginTop: "50px",
+            marginBottom: "50px"
+        },
+        bodyContainer: {
+            backgroundColor: theme.palette.primary.main,
+            display: "flex",
+            justifyContent: "center",
+            paddingTop: "20px",
+            paddingBottom: "20px",
+        },
+        dateContainer: {
+            backgroundColor: "blue",
+            display: "flex",
+            flexDirection: "column",
+            // justifyContent: "center",
+        },
+        paper: {
+            width: "150px",
+            height: "120px",
+            margin: "20px",
+            marginRight: "30px",
+            borderRadius: 8,
+        },
+        descContainer: {
+            backgroundColor: "pink",
+            width: "500px",
+            padding: "20px",
+        },
+
+    })
+);
 
 const EventPage: NextPage<Props> = ({ event }) => {
-    const classes = useStyles();
+    const styles = useStyles();
 
     if (!event) {
         return <Error statusCode={404} />;
@@ -26,8 +81,37 @@ const EventPage: NextPage<Props> = ({ event }) => {
         <>
             <Header />
 
-            <CoreTypography variant="h1">{event.name}</CoreTypography>
-            <CoreTypography variant="h5">{JSON.stringify(event)}</CoreTypography>
+            <Container maxWidth="xl" className={styles.eventHeader}>
+                <img src={`/${constants.org.images.logo}`} className={styles.logo} alt={`${constants.org.name.short} logo`} />
+                <CoreTypography variant="h1">Event Description</CoreTypography>
+            </Container>
+            <Container maxWidth="xl" className={styles.eventName}>
+                <CoreTypography variant="h1"> {event.name} </CoreTypography>
+            </Container>
+            <Container maxWidth="xl" className={styles.bodyContainer}>
+                {/* <Container maxWidth="md" style={{backgroundColor: "blue"}}>test</Container>
+                <Container maxWidth="sm">test</Container> */}
+                <div className={styles.dateContainer}>
+                    <Paper className={styles.paper}></Paper>
+                    <Paper className={styles.paper}></Paper>
+                </div>
+                <div className={styles.descContainer}>
+                    <CoreTypography variant="body2">
+                        Join us on the third Saturday of each month for a Saturday Spruce Up.
+                        Each month's location and activity will change. <br /> <br />
+                        This month we will be heading to Danny Mayfield Park in Mechanicsville. 
+                        We will meet at the park pavilion, across from Maynard Elementary. Parking is located along the street. <br /> <br />
+                        Pre-registration is required. Sign ups will close on February 18, 2021. <br /> <br />
+                        All supplies will be provided. Please wear closed-toed shoes and bring water. <br /> <br />
+                        COVID policies: please wear a mask during supplies distribution and safety instruction. Pre-registration is required.
+                    </CoreTypography>
+                </div>
+            </Container>
+            <Container maxWidth="xl" className={ `${styles.eventName} ${styles.caption}`}>
+                <Container maxWidth="sm">
+                    <CoreTypography variant="h4"> {event.caption} </CoreTypography>
+                </Container>
+            </Container>
 
             <Footer />
         </>

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -10,6 +10,7 @@ import colors from "src/components/core/colors";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Card from "@material-ui/core/Card";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
 import Container from "@material-ui/core/Container";
 import CardContent from "@material-ui/core/CardContent";
 import ScheduleIcon from "@material-ui/icons/Schedule";
@@ -48,11 +49,18 @@ const useStyles = makeStyles((theme: Theme) =>
             marginBottom: "50px",
         },
         bodyContainer: {
+            [theme.breakpoints.down("sm")]: {
+                flexDirection: "column",
+                alignItems: "center",
+            },
             backgroundColor: theme.palette.primary.light,
             display: "flex",
             justifyContent: "center",
         },
         dateContainer: {
+            [theme.breakpoints.down("sm")]: {
+                flexDirection: "row",
+            },
             display: "flex",
             flexDirection: "column",
         },

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -11,16 +11,16 @@ import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Card from "@material-ui/core/Card";
 import Container from "@material-ui/core/Container";
-import CardContent from '@material-ui/core/CardContent';
-import ScheduleIcon from '@material-ui/icons/Schedule';
-import LocationOnIcon from '@material-ui/icons/LocationOn';
-import { isSameDay, format, addDays } from 'date-fns';
+import CardContent from "@material-ui/core/CardContent";
+import ScheduleIcon from "@material-ui/icons/Schedule";
+import LocationOnIcon from "@material-ui/icons/LocationOn";
+import { isSameDay, format, addDays } from "date-fns";
 
 interface Props {
     event: Event;
 }
 
-const useStyles = makeStyles((theme: Theme) => 
+const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         eventHeader: {
             backgroundColor: theme.palette.primary.main,
@@ -29,32 +29,29 @@ const useStyles = makeStyles((theme: Theme) =>
             color: colors.white,
             display: "flex",
             alignItems: "center",
-            justifyContent: "center",          
+            justifyContent: "center",
         },
         logo: {
             width: "80px",
-            marginRight: "20px"
+            marginRight: "20px",
         },
         eventName: {
             textAlign: "center",
             height: "110px",
             display: "flex",
             alignItems: "center",
-            justifyContent: "center",          
+            justifyContent: "center",
         },
         caption: {
             marginTop: "50px",
-            marginBottom: "50px"
+            marginBottom: "50px",
         },
         bodyContainer: {
-            backgroundColor: theme.palette.primary.main,
+            backgroundColor: theme.palette.primary.light,
             display: "flex",
             justifyContent: "center",
-            paddingTop: "20px",
-            paddingBottom: "20px",
         },
         dateContainer: {
-            // backgroundColor: "blue",
             display: "flex",
             flexDirection: "column",
         },
@@ -66,7 +63,6 @@ const useStyles = makeStyles((theme: Theme) =>
             borderRadius: 8,
         },
         descContainer: {
-            // backgroundColor: "pink",
             width: "500px",
             padding: "20px",
         },
@@ -82,7 +78,7 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         cardText: {
             marginTop: "15px",
-        }
+        },
     })
 );
 
@@ -93,9 +89,9 @@ const EventPage: NextPage<Props> = ({ event }) => {
         return <Error statusCode={404} />;
     }
     event.startDate = new Date(event.startDate as Date);
-    event.endDate = new Date(event.endDate as Date); 
+    event.endDate = new Date(event.endDate as Date);
     //TODO remove addDays, adding 2 days to test diff dates
-    // event.endDate = addDays(new Date(event.endDate as Date), 2); 
+    // event.endDate = addDays(new Date(event.endDate as Date), 2);
 
     // slightly diff display between events on the same day vs diff days
     const getTime = () => {
@@ -103,35 +99,38 @@ const EventPage: NextPage<Props> = ({ event }) => {
             return (
                 <div>
                     <CoreTypography variant="subtitle1" className={styles.cardText}>
-                        {format(event.startDate as Date, "ccc, MMMM dd, yyyy")} 
-                        <br/>
+                        {format(event.startDate as Date, "ccc, MMMM dd, yyyy")}
+                        <br />
                         {`${format(event.startDate as Date, "h:m a")}
                         – ${format(event.endDate as Date, "h:m a")}`}
                     </CoreTypography>
                 </div>
             );
-        }
-        else {
+        } else {
             return (
                 <div>
                     <CoreTypography variant="subtitle1" className={styles.cardText}>
-                        {format(event.startDate as Date, "ccc, MMMM dd, yyyy")} <br/>
-                        {`${format(event.startDate as Date, "h:m a")} – `} 
-                        <br/>
-                        {format(event.endDate as Date, "ccc, MMMM dd, yyyy")} <br/>
+                        {format(event.startDate as Date, "ccc, MMMM dd, yyyy")} <br />
+                        {`${format(event.startDate as Date, "h:m a")} – `}
+                        <br />
+                        {format(event.endDate as Date, "ccc, MMMM dd, yyyy")} <br />
                         {format(event.endDate as Date, "h:m a")}
                     </CoreTypography>
                 </div>
             );
         }
-    }
+    };
 
     return (
         <>
             <Header />
 
             <Container maxWidth="xl" className={styles.eventHeader}>
-                <img src={`/${constants.org.images.logo}`} className={styles.logo} alt={`${constants.org.name.short} logo`} />
+                <img
+                    src={`/${constants.org.images.logo}`}
+                    className={styles.logo}
+                    alt={`${constants.org.name.short} logo`}
+                />
                 <CoreTypography variant="h1">Event Description</CoreTypography>
             </Container>
             <Container maxWidth="xl" className={styles.eventName}>
@@ -142,7 +141,7 @@ const EventPage: NextPage<Props> = ({ event }) => {
                     <Card className={styles.card}>
                         <CardContent>
                             <div className={styles.cardTitle}>
-                                <ScheduleIcon className={styles.titleIcon}/>
+                                <ScheduleIcon className={styles.titleIcon} />
                                 <CoreTypography variant="h5" className={styles.titleName}>
                                     Event Time
                                 </CoreTypography>
@@ -155,7 +154,7 @@ const EventPage: NextPage<Props> = ({ event }) => {
                     <Card className={styles.card}>
                         <CardContent>
                             <div className={styles.cardTitle}>
-                                <LocationOnIcon className={styles.titleIcon}/>
+                                <LocationOnIcon className={styles.titleIcon} />
                                 <CoreTypography variant="h5" className={styles.titleName}>
                                     Location
                                 </CoreTypography>
@@ -169,17 +168,18 @@ const EventPage: NextPage<Props> = ({ event }) => {
                 <div className={styles.descContainer}>
                     <CoreTypography variant="body2">
                         {/* Note: This is a placeholder till we get formatted desc */}
-                        Join us on the third Saturday of each month for a Saturday Spruce Up.
-                        Each month's location and activity will change. <br/> <br/>
-                        This month we will be heading to Danny Mayfield Park in Mechanicsville. 
-                        We will meet at the park pavilion, across from Maynard Elementary. Parking is located along the street. <br/> <br/>
-                        Pre-registration is required. Sign ups will close on February 18, 2021. <br/> <br/>
-                        All supplies will be provided. Please wear closed-toed shoes and bring water. <br/> <br/>
-                        COVID policies: please wear a mask during supplies distribution and safety instruction. Pre-registration is required.
+                        Join us on the third Saturday of each month for a Saturday Spruce Up. Each month&apos;s location
+                        and activity will change. <br /> <br />
+                        This month we will be heading to Danny Mayfield Park in Mechanicsville. We will meet at the park
+                        pavilion, across from Maynard Elementary. Parking is located along the street. <br /> <br />
+                        Pre-registration is required. Sign ups will close on February 18, 2021. <br /> <br />
+                        All supplies will be provided. Please wear closed-toed shoes and bring water. <br /> <br />
+                        COVID policies: please wear a mask during supplies distribution and safety instruction.
+                        Pre-registration is required.
                     </CoreTypography>
                 </div>
             </Container>
-            <Container maxWidth="xl" className={ `${styles.eventName} ${styles.caption}`}>
+            <Container maxWidth="xl" className={`${styles.eventName} ${styles.caption}`}>
                 <Container maxWidth="sm">
                     <CoreTypography variant="h4"> {event.caption} </CoreTypography>
                 </Container>

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -14,6 +14,7 @@ import Container from "@material-ui/core/Container";
 import CardContent from '@material-ui/core/CardContent';
 import ScheduleIcon from '@material-ui/icons/Schedule';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
+import { isSameDay, format, addDays } from 'date-fns';
 
 interface Props {
     event: Event;
@@ -53,10 +54,9 @@ const useStyles = makeStyles((theme: Theme) =>
             paddingBottom: "20px",
         },
         dateContainer: {
-            backgroundColor: "blue",
+            // backgroundColor: "blue",
             display: "flex",
             flexDirection: "column",
-            // justifyContent: "center",
         },
         card: {
             width: "160px",
@@ -66,7 +66,7 @@ const useStyles = makeStyles((theme: Theme) =>
             borderRadius: 8,
         },
         descContainer: {
-            backgroundColor: "pink",
+            // backgroundColor: "pink",
             width: "500px",
             padding: "20px",
         },
@@ -92,16 +92,39 @@ const EventPage: NextPage<Props> = ({ event }) => {
     if (!event) {
         return <Error statusCode={404} />;
     }
+    event.startDate = new Date(event.startDate as Date);
+    event.endDate = new Date(event.endDate as Date); 
+    //TODO remove addDays, adding 2 days to test diff dates
+    // event.endDate = addDays(new Date(event.endDate as Date), 2); 
 
-
+    // slightly diff display between events on the same day vs diff days
     const getTime = () => {
-        return (
-            <div>
-                Tue, September 20, 2021 10:00 AM - 12:00 PM
-            </div>
-        );
+        if (isSameDay(event.startDate as Date, event.endDate as Date)) {
+            return (
+                <div>
+                    <CoreTypography variant="subtitle1" className={styles.cardText}>
+                        {format(event.startDate as Date, "ccc, MMMM dd, yyyy")} 
+                        <br/>
+                        {`${format(event.startDate as Date, "h:m a")}
+                        – ${format(event.endDate as Date, "h:m a")}`}
+                    </CoreTypography>
+                </div>
+            );
+        }
+        else {
+            return (
+                <div>
+                    <CoreTypography variant="subtitle1" className={styles.cardText}>
+                        {format(event.startDate as Date, "ccc, MMMM dd, yyyy")} <br/>
+                        {`${format(event.startDate as Date, "h:m a")} – `} 
+                        <br/>
+                        {format(event.endDate as Date, "ccc, MMMM dd, yyyy")} <br/>
+                        {format(event.endDate as Date, "h:m a")}
+                    </CoreTypography>
+                </div>
+            );
+        }
     }
-
 
     return (
         <>
@@ -115,8 +138,6 @@ const EventPage: NextPage<Props> = ({ event }) => {
                 <CoreTypography variant="h1"> {event.name} </CoreTypography>
             </Container>
             <Container maxWidth="xl" className={styles.bodyContainer}>
-                {/* <Container maxWidth="md" style={{backgroundColor: "blue"}}>test</Container>
-                <Container maxWidth="sm">test</Container> */}
                 <div className={styles.dateContainer}>
                     <Card className={styles.card}>
                         <CardContent>
@@ -147,6 +168,7 @@ const EventPage: NextPage<Props> = ({ event }) => {
                 </div>
                 <div className={styles.descContainer}>
                     <CoreTypography variant="body2">
+                        {/* Note: This is a placeholder till we get formatted desc */}
                         Join us on the third Saturday of each month for a Saturday Spruce Up.
                         Each month's location and activity will change. <br/> <br/>
                         This month we will be heading to Danny Mayfield Park in Mechanicsville. 

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -25,19 +25,20 @@ const useStyles = makeStyles((theme: Theme) =>
         eventHeader: {
             backgroundColor: theme.palette.primary.main,
             textAlign: "center",
-            height: "200px",
+            height: "220px",
             color: colors.white,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
+            paddingBottom: "30px",
         },
         logo: {
-            width: "80px",
+            width: "90px",
             marginRight: "20px",
         },
         eventName: {
             textAlign: "center",
-            height: "110px",
+            minHeight: "110px",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -134,7 +135,7 @@ const EventPage: NextPage<Props> = ({ event }) => {
                 <CoreTypography variant="h1">Event Description</CoreTypography>
             </Container>
             <Container maxWidth="xl" className={styles.eventName}>
-                <CoreTypography variant="h1"> {event.name} </CoreTypography>
+                <CoreTypography variant="h2"> {event.name} </CoreTypography>
             </Container>
             <Container maxWidth="xl" className={styles.bodyContainer}>
                 <div className={styles.dateContainer}>

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -1,0 +1,68 @@
+import Header from "src/components/Header";
+import Footer from "src/components/Footer";
+import { getEvent } from "server/actions/Event";
+import { Event } from "utils/types";
+import { GetStaticPropsContext, NextPage } from "next";
+import constants from "utils/constants";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import Error from "next/error";
+import errors from "utils/errors";
+import CoreTypography from "src/components/core/typography/CoreTypography";
+
+interface Props {
+    event: Event;
+}
+
+const useStyles = makeStyles((theme: Theme) => createStyles({}));
+
+const EventPage: NextPage<Props> = ({ event }) => {
+    const classes = useStyles();
+
+    if (!event) {
+        return <Error statusCode={404} />;
+    }
+
+    return (
+        <>
+            <Header />
+
+            <CoreTypography variant="h1">{event.name}</CoreTypography>
+            <CoreTypography variant="h5">{JSON.stringify(event)}</CoreTypography>
+
+            <Footer />
+        </>
+    );
+};
+
+// query data and pass it to component here. this is run server-side
+export async function getStaticProps(context: GetStaticPropsContext) {
+    try {
+        console.log(context.params?.eventId);
+        const event: Event = await getEvent(context.params?.eventId as string);
+
+        return {
+            props: {
+                event: JSON.parse(JSON.stringify(event)) as Event,
+            },
+            revalidate: constants.revalidate.eventDesc,
+        };
+    } catch (error) {
+        return {
+            props: {},
+            revalidate: constants.revalidate.eventDesc,
+        };
+    }
+}
+
+// required for dynamic pages: prerender events at build time
+export async function getStaticPaths() {
+    const events: Event[] = []; //await getEvents({});
+
+    const paths = events.map(event => ({
+        params: { name: event._id },
+    }));
+
+    return { paths, fallback: true };
+}
+
+export default EventPage;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -20,9 +20,9 @@ export interface Event {
     maxVolunteers?: number;
     location?: string;
     startDate?: Date;
-    startTime?: Date;
+    // startTime?: Date;
     endDate?: Date;
-    endTime?: Date;
+    // endTime?: Date;
     startRegistration?: Date;
     endRegistration?: Date;
     hours?: number;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -18,11 +18,11 @@ export interface Event {
     description?: string;
     caption?: string;
     maxVolunteers?: number;
+    location?: string;
     startDate?: Date;
     startTime?: Date;
     endDate?: Date;
     endTime?: Date;
-    location?: string;
     startRegistration?: Date;
     endRegistration?: Date;
     hours?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3330,6 +3330,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.0.0-beta.5:
+  version "2.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-beta.5.tgz#90885db3772802d55519cd12acd49de56aca1059"
+  integrity sha512-GS5yi964NDFNoja9yOdWFj9T97T67yLrUeJZgddHaVfc/6tHWtX7RXocuubmZkNzrZUZ9BqBOW7jTR5OoWjJ1w==
+
 debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,6 +1227,13 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.11.3":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"


### PR DESCRIPTION
This PR mainly implements the page for a single event's description. I attached some screenshots at the end so you all know how it looks. Note that the description is hardcoded for now since we don't support rich text. I'll probably change that to use `events.description` before I merge it.

I also changed some other things:

1. Updated the event type to not have any time-specific fields. We'll be including the time in the startDate (the `Date` type can hold the time as well).
2. Changed typography styles. I enlarged h1 (that's the "Event Description" text that is massive), then h2 is old h1.
3. Slightly changed some footer css props to make it more responsive.

Page for a single day event:
![Screen Shot 2021-02-25 at 2 44 10 PM](https://user-images.githubusercontent.com/37582248/109209111-26c31780-7779-11eb-8103-cebaa5bff2b6.png)

Page on mobile display:
![Screen Shot 2021-02-25 at 2 44 24 PM](https://user-images.githubusercontent.com/37582248/109209109-262a8100-7779-11eb-9d4e-1a1ece95670c.png)

Event time card for multi-day events:
![Screen Shot 2021-02-25 at 2 44 50 PM](https://user-images.githubusercontent.com/37582248/109209104-2591ea80-7779-11eb-836b-d92e590f691b.png)

