### PR TITLE
Zaviermiller kkb 39 event card

### DIFF
--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -27,7 +27,7 @@ export const getEvents = async function () {
     await mongoDB();
 
     const events = (await EventSchema.find({})) as Array<Event>;
-    if (!!events && !events.length) {
+    if (!events || !events.length) {
         throw new Error("No events");
     }
 

--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -27,7 +27,7 @@ export const getEvents = async function () {
     await mongoDB();
 
     const events = (await EventSchema.find({})) as Array<Event>;
-    if (!events.length) {
+    if (!!events && !events.length) {
         throw new Error("No events");
     }
 

--- a/src/components/DummyDate/index.tsx
+++ b/src/components/DummyDate/index.tsx
@@ -28,13 +28,14 @@ export default function DateAndTimePickers() {
 
     return (
         <>
-            <CoreTypography variant="h1">{`${constants.org.name.full} events`}</CoreTypography>
+            {/* <CoreTypography variant="h1">{`${constants.org.name.full} events`}</CoreTypography> */}
             <form className={classes.container} noValidate>
                 <TextField
                     id="datetime-local"
                     label="Event Start"
                     type="datetime-local"
                     defaultValue="2021-05-24T10:30"
+                    color="secondary"
                     className={classes.textField}
                     InputLabelProps={{
                         shrink: true,

--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -1,28 +1,38 @@
+// utils
 import React, { useState, ReactNode } from "react";
 import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
+import { useRouter } from "next/router";
 
+// components
+import { Box, Grid } from "@material-ui/core";
 import Card from "@material-ui/core/Card";
 import CardActionArea from "@material-ui/core/CardActionArea";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
 import IconButton from "@material-ui/core/IconButton";
-import MoreVertIcon from "@material-ui/icons/MoreVert";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import CoreTypography from "../core/typography/CoreTypography";
 
+// icons
+import MoreVertIcon from "@material-ui/icons/MoreVert";
+import RoomOutlinedIcon from "@material-ui/icons/RoomOutlined";
+import ScheduleOutlinedIcon from "@material-ui/icons/ScheduleOutlined";
+
+// misc
 import { Event } from "utils/types";
 import constants from "utils/constants";
-import { useRouter } from "next/router";
+import colors from "src/components/core/colors";
 
+// create styles for material-ui
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         eventCard: {
-            height: 400,
+            height: 360,
             borderRadius: 25,
             // boxShadow: "0 3px 5px -1px rgba(0,0,0,.2),0 5px 8px 0 rgba(0,0,0,.14),0 1px 14px 0 rgba(0,0,0,.12)",
-            transition: ".3s",
+            transition: ".3s ease-out",
             position: "relative",
             cursor: "pointer",
             minWidth: 300,
@@ -30,15 +40,22 @@ const useStyles = makeStyles((theme: Theme) =>
         thumbnailPlaceholder: {
             background: `#97BBCB url("/${constants.org.images.defaultCard}") no-repeat center`,
             backgroundSize: "100px",
-            height: 220,
+            height: 200,
             transition: ".3s",
             width: "100%",
+        },
+        hidden: {
+            opacity: 0,
+        },
+        shown: {
+            opacity: 1,
         },
         thumbnailOverlay: {
             backgroundColor: "rgba(0,0,0,.5)",
             width: "100%",
             height: "100%",
             position: "relative",
+            transition: ".5s",
         },
         eventDate: {
             width: 65,
@@ -63,6 +80,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface Props {
     event: Event;
+    isAdmin?: boolean;
 }
 
 interface ThumbProps {
@@ -70,22 +88,31 @@ interface ThumbProps {
     children: ReactNode;
 }
 
-const EventCard: React.FC<Props> = ({ event }) => {
+const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
     const classes = useStyles();
     const router = useRouter();
 
-    // readable event date
+    // display variables for event data
     const eventMonth = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][
         new Date(event.startDate as Date).getMonth()
     ];
     const eventDate = new Date(event.startDate as Date).getDate();
-
+    const eventLocation = event.location?.split(",")[0];
+    console.log(eventLocation);
+    const eventStartTime = `${new Date(event.startDate as Date).getHours() % 12 || 12}:${new Date(
+        event.startDate as Date
+    ).getMinutes()} ${new Date(event.startDate as Date).getHours() > 11 ? "PM" : "AM"}`;
+    const eventEndTime = `${new Date(event.endDate as Date).getHours() % 12 || 12}:${new Date(
+        event.endDate as Date
+    ).getMinutes()} ${new Date(event.endDate as Date).getHours() > 11 ? "PM" : "AM"}`;
     // state
     const [hover, setHover] = useState(false);
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [menuOpen, setMenuOpen] = useState(false);
 
     const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
         setAnchorEl(event.currentTarget);
         setMenuOpen(true);
         console.log(event.currentTarget, anchorEl);
@@ -102,11 +129,11 @@ const EventCard: React.FC<Props> = ({ event }) => {
 
         return (
             <div
-                className={`${hasImage ? "" : classes.thumbnailPlaceholder}`}
+                className={`${classes.thumbnailPlaceholder}`}
                 style={
                     hasImage
                         ? {
-                              height: 220,
+                              height: 200,
                               width: "100%",
                               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                               background: `url("${event.image?.url}") no-repeat center`,
@@ -129,58 +156,107 @@ const EventCard: React.FC<Props> = ({ event }) => {
     };
 
     return (
-        <Card
-            onMouseEnter={e => handleHover(e)}
-            onMouseLeave={e => handleHoverLeave(e)}
-            onClick={() => {
-                void router.push(`/events/${event._id as string}`);
-            }}
-            className={`${classes.eventCard}`}
-            elevation={hover ? 14 : 7}
-        >
-            {/* <CardActionArea> */}
-            <EventThumbnail localHover={hover}>
-                {/* TODO: change to box */}
-                <div className={classes.eventDate}>
-                    <span>
+        <div>
+            <Card
+                onMouseEnter={e => handleHover(e)}
+                onMouseLeave={e => handleHoverLeave(e)}
+                onClick={() => {
+                    void router.push(`/events/${event._id as string}`);
+                }}
+                className={`${classes.eventCard}`}
+                elevation={hover ? 20 : 7}
+            >
+                {/* <CardActionArea> */}
+                <EventThumbnail localHover={hover}>
+                    <Box className={classes.eventDate}>
+                        <span>
+                            <CoreTypography variant="h5" style={{ marginBottom: 0, textTransform: "uppercase" }}>
+                                {eventMonth}
+                            </CoreTypography>
+                            <CoreTypography
+                                variant="h3"
+                                style={{ marginBottom: 0, lineHeight: "20px", fontSize: "1.75em" }}
+                            >
+                                {eventDate}
+                            </CoreTypography>
+                        </span>
+                    </Box>
+                    {isAdmin ? (
+                        <div className={classes.thumbnailOverlay} style={hover ? { opacity: 1 } : { opacity: 0 }}>
+                            <IconButton
+                                aria-label="more options"
+                                aria-haspopup="true"
+                                onClick={e => handleClick(e)}
+                                style={{ position: "absolute", zIndex: 1000, top: "3%" }}
+                            >
+                                <MoreVertIcon htmlColor="white" />
+                            </IconButton>
+                        </div>
+                    ) : null}
+                </EventThumbnail>
+                <CardContent>
+                    <div style={{ height: 100, overflow: "hidden" }}>
+                        <CoreTypography gutterBottom variant="h3" className={classes.title}>
+                            {event.name}
+                        </CoreTypography>
                         <CoreTypography
-                            variant="h5"
-                            style={{ marginBottom: 0, textTransform: "uppercase", fontSize: "1em" }}
+                            variant="body2"
+                            style={{
+                                color: "rgba(0,0,0,.4)",
+                                fontFamily: "Ubuntu",
+                            }}
                         >
-                            {eventMonth}
+                            {event.description}
                         </CoreTypography>
-                        <CoreTypography variant="h3" style={{ marginBottom: 0, lineHeight: "20px" }}>
-                            {eventDate}
-                        </CoreTypography>
-                    </span>
-                </div>
-
-                <div className={classes.thumbnailOverlay} style={hover && !hover ? { opacity: 1 } : { opacity: 0 }}>
-                    <IconButton
-                        aria-label="more options"
-                        aria-haspopup="true"
-                        onClick={e => handleClick(e)}
-                        style={{ position: "absolute", zIndex: 1000, top: "3%" }}
-                    >
-                        <MoreVertIcon htmlColor="white" />
-                    </IconButton>
-                    <Menu id="simple-menu" anchorEl={anchorEl} keepMounted open={menuOpen} onClose={handleClose}>
-                        <MenuItem onClick={handleClose}>Edit</MenuItem>
-                        <MenuItem onClick={handleClose}>Manage</MenuItem>
-                        <MenuItem onClick={handleClose}>Delete</MenuItem>
-                    </Menu>
-                </div>
-            </EventThumbnail>
-            <CardContent>
-                <CoreTypography gutterBottom variant="h3" className={classes.title}>
-                    {event.name}
-                </CoreTypography>
-                <CoreTypography variant="body2" color="textSecondary">
-                    {event.description}
-                </CoreTypography>
-            </CardContent>
-            {/* </CardActionArea> */}
-        </Card>
+                    </div>
+                    {/* location and time info */}
+                    <Grid container wrap="nowrap" justify="center" alignItems="center" spacing={1}>
+                        <RoomOutlinedIcon color="primary"></RoomOutlinedIcon>
+                        <Grid item xs={6} style={{ display: "flex", alignItems: "center" }}>
+                            <CoreTypography
+                                variant="caption"
+                                style={{
+                                    whiteSpace: "nowrap",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    color: colors.pink,
+                                    fontWeight: 600,
+                                    fontFamily: "Ubuntu",
+                                    fontSize: 13,
+                                }}
+                                component="p"
+                            >
+                                {eventLocation}
+                            </CoreTypography>
+                        </Grid>
+                        <ScheduleOutlinedIcon color="primary"></ScheduleOutlinedIcon>
+                        <Grid item xs={5}>
+                            <CoreTypography
+                                variant="caption"
+                                style={{
+                                    whiteSpace: "nowrap",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    color: colors.pink,
+                                    fontWeight: 600,
+                                    fontFamily: "Ubuntu",
+                                    fontSize: 13,
+                                }}
+                                component="p"
+                            >
+                                {eventStartTime} - {eventEndTime}
+                            </CoreTypography>
+                        </Grid>
+                    </Grid>
+                </CardContent>
+                {/* </CardActionArea> */}
+            </Card>
+            <Menu id="simple-menu" anchorEl={anchorEl} keepMounted open={menuOpen}>
+                <MenuItem onClick={handleClose}>Edit</MenuItem>
+                <MenuItem onClick={handleClose}>Manage</MenuItem>
+                <MenuItem onClick={handleClose}>Delete</MenuItem>
+            </Menu>
+        </div>
     );
 };
 

--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -98,13 +98,13 @@ const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
     ];
     const eventDate = new Date(event.startDate as Date).getDate();
     const eventLocation = event.location?.split(",")[0];
-    console.log(eventLocation);
-    const eventStartTime = `${new Date(event.startDate as Date).getHours() % 12 || 12}:${new Date(
+    const eventStartTime = `${new Date(event.startDate as Date).getHours() % 12 || 12}:${`0${new Date(
         event.startDate as Date
-    ).getMinutes()} ${new Date(event.startDate as Date).getHours() > 11 ? "PM" : "AM"}`;
-    const eventEndTime = `${new Date(event.endDate as Date).getHours() % 12 || 12}:${new Date(
+    ).getMinutes()}`.slice(-2)} ${new Date(event.startDate as Date).getHours() >= 11 ? "PM" : "AM"}`;
+    const eventEndTime = `${new Date(event.endDate as Date).getHours() % 12 || 12}:${`0${new Date(
         event.endDate as Date
-    ).getMinutes()} ${new Date(event.endDate as Date).getHours() > 11 ? "PM" : "AM"}`;
+    ).getMinutes()}`.slice(-2)} ${new Date(event.endDate as Date).getHours() > 11 ? "PM" : "AM"}`;
+
     // state
     const [hover, setHover] = useState(false);
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -130,6 +130,7 @@ const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
         return (
             <div
                 className={`${classes.thumbnailPlaceholder}`}
+                id="eventThumb"
                 style={
                     hasImage
                         ? {
@@ -195,8 +196,8 @@ const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
                     ) : null}
                 </EventThumbnail>
                 <CardContent>
-                    <div style={{ height: 100, overflow: "hidden" }}>
-                        <CoreTypography gutterBottom variant="h3" className={classes.title}>
+                    <div style={{ height: 105, overflow: "hidden" }}>
+                        <CoreTypography gutterBottom variant="h3" className={classes.title} id="eventName">
                             {event.name}
                         </CoreTypography>
                         <CoreTypography
@@ -205,6 +206,7 @@ const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
                                 color: "rgba(0,0,0,.4)",
                                 fontFamily: "Ubuntu",
                             }}
+                            id="eventDesc"
                         >
                             {event.description}
                         </CoreTypography>
@@ -224,6 +226,7 @@ const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
                                     fontFamily: "Ubuntu",
                                     fontSize: 13,
                                 }}
+                                id="eventLoc"
                                 component="p"
                             >
                                 {eventLocation}
@@ -242,6 +245,7 @@ const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
                                     fontFamily: "Ubuntu",
                                     fontSize: 13,
                                 }}
+                                id="eventTime"
                                 component="p"
                             >
                                 {eventStartTime} - {eventEndTime}

--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
             minWidth: 300,
         },
         thumbnailPlaceholder: {
-            background: `#97BBCB url("/${constants.org.images.defaultCard}") no-repeat center`,
+            background: `${theme.palette.secondary.main} url("/${constants.org.images.defaultCard}") no-repeat center`,
             backgroundSize: "100px",
             height: 200,
             transition: ".3s",
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme: Theme) =>
         eventDate: {
             width: 65,
             height: 65,
-            backgroundColor: "#87CD9B",
+            backgroundColor: colors.green,
             position: "absolute",
             right: "5%",
             top: "5%",

--- a/src/components/EventsContainer/index.tsx
+++ b/src/components/EventsContainer/index.tsx
@@ -4,6 +4,8 @@ import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import Container from "@material-ui/core/Container";
 import Grid from "@material-ui/core/Grid";
 import Paper from "@material-ui/core/Paper";
+import { Event } from "utils/types";
+import EventCard from "../EventCard";
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -13,13 +15,28 @@ const useStyles = makeStyles((theme: Theme) =>
     })
 );
 
-export default function EventsContainer() {
+interface Props {
+    events: Event[];
+}
+
+export default function EventsContainer(props: Props) {
     const styles = useStyles();
 
     return (
         <React.Fragment>
             <Container maxWidth="xl" className={styles.container}>
                 <Grid container direction="row" spacing={6} justify="center">
+                    {props.events.map((event: Event, i: number) => {
+                        return (
+                            <Grid item xs={12} sm={6} md={4} xl={3} key={i}>
+                                <EventCard event={event} />
+                            </Grid>
+                        );
+                    })}
+                    {/* 
+                    
+                    TODO: remove placeholder
+
                     <Grid item>
                         <Paper style={{ height: 250, width: 220 }} />
                     </Grid>
@@ -37,7 +54,9 @@ export default function EventsContainer() {
                     </Grid>
                     <Grid item>
                         <Paper style={{ height: 250, width: 220 }} />
-                    </Grid>
+                    </Grid> 
+                    
+                    */}
                 </Grid>
             </Container>
         </React.Fragment>

--- a/src/components/EventsContainer/index.tsx
+++ b/src/components/EventsContainer/index.tsx
@@ -28,7 +28,7 @@ export default function EventsContainer(props: Props) {
                 <Grid container direction="row" spacing={6} justify="center">
                     {props.events.map((event: Event, i: number) => {
                         return (
-                            <Grid item xs={12} sm={6} md={4} xl={3} key={i}>
+                            <Grid item xs={12} sm={8} md={5} lg={4} key={i}>
                                 <EventCard event={event} />
                             </Grid>
                         );

--- a/src/components/EventsContainer/index.tsx
+++ b/src/components/EventsContainer/index.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 
-import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
 import Container from "@material-ui/core/Container";
-import Grid from "@material-ui/core/Grid";
-import Paper from "@material-ui/core/Paper";
-import { Event } from "utils/types";
 import EventCard from "../EventCard";
+import Grid from "@material-ui/core/Grid";
+
+import { makeStyles, createStyles, Theme } from "@material-ui/core/styles";
+
+import { Event } from "utils/types";
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -7,10 +7,12 @@ const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         container: {
             backgroundColor: theme.palette.primary.main,
-            height: "80px",
+            height: "100px",
             width: "100%",
             display: "flex",
             alignItems: "center",
+            position: "relative",
+            top: 0,
         },
         headerBanner: {
             height: "60px",

--- a/src/components/core/typography/CoreTypography.tsx
+++ b/src/components/core/typography/CoreTypography.tsx
@@ -17,7 +17,7 @@ export const typographyStyles: Readonly<Record<Variant, TypographyStyleOptions>>
     h2: {
         fontFamily: "Ubuntu",
         fontWeight: 800,
-        fontSize: "1.5rem",
+        fontSize: "1.75rem",
         fontStyle: "normal",
         fontFeatureSettings: "'liga' off",
         lineHeight: "140%",

--- a/src/components/core/typography/CoreTypography.tsx
+++ b/src/components/core/typography/CoreTypography.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ElementType } from "react";
 import { Typography } from "@material-ui/core";
 import { TypographyStyleOptions } from "@material-ui/core/styles/createTypography";
 
@@ -95,7 +95,7 @@ export const typographyStyles: Readonly<Record<Variant, TypographyStyleOptions>>
 
 type Props = Omit<React.ComponentProps<typeof Typography>, "variant"> & {
     variant?: Variant;
-};
+} & { component?: string | HTMLElement };
 
 const CoreTypography: React.FC<Props> = ({ children, variant, ...rest }) => {
     const coreVariant: Variant = variant ?? "body2";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,8 @@ import { AppProps } from "next/app";
 import { ThemeProvider } from "@material-ui/core/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import theme from "utils/theme";
+import Header from "src/components/Header";
+import Footer from "src/components/Footer";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
     React.useEffect(() => {
@@ -24,7 +26,32 @@ export default function MyApp({ Component, pageProps }: AppProps) {
             <ThemeProvider theme={theme}>
                 {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
                 <CssBaseline />
-                <Component {...pageProps} />
+                <Header />
+                <div className="container">
+                    <Component {...pageProps} />
+                    <style jsx>{`
+                        .container {
+                            display: flex;
+                            flex-direction: column;
+                            justify-content: center;
+                            align-items: center;
+                        }
+                    `}</style>
+
+                    <style jsx global>{`
+                        html,
+                        body {
+                            padding: 0;
+                            margin: 0;
+                            font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
+                                Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+                        }
+                        * {
+                            box-sizing: border-box;
+                        }
+                    `}</style>
+                    <Footer />
+                </div>
             </ThemeProvider>
         </React.Fragment>
     );

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -128,8 +128,6 @@ const EventPage: NextPage<Props> = ({ event }) => {
 
     return (
         <>
-            <Header />
-
             <Container maxWidth="xl" className={styles.eventHeader}>
                 <img
                     src={`/${constants.org.images.logo}`}
@@ -189,8 +187,6 @@ const EventPage: NextPage<Props> = ({ event }) => {
                     <CoreTypography variant="h4"> {event.caption} </CoreTypography>
                 </Container>
             </Container>
-
-            <Footer />
         </>
     );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import urls from "utils/urls";
 
 import { Event } from "utils/types";
 import { useRouter } from "next/router";
+import withWidth from "@material-ui/core/withWidth";
 import { getEvents } from "server/actions/Event";
 import constants from "utils/constants";
 import { Button, Container, createStyles, Grid, makeStyles, Theme } from "@material-ui/core";
@@ -15,6 +16,7 @@ import CoreTypography from "src/components/core/typography";
 
 interface Props {
     events: Event[];
+    width: string;
 }
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -29,16 +31,24 @@ const useStyles = makeStyles((theme: Theme) =>
     })
 );
 
-const Home: NextPage<Props> = ({ events }) => {
+const Home: NextPage<Props> = ({ events, width }) => {
     const classes = useStyles();
 
     return (
         <div style={{ width: "100%" }}>
             <div className={classes.jumbotron}>
-                <Grid container spacing={3} direction="row" justify="center" style={{ width: "100%" }}>
+                <Grid
+                    container
+                    spacing={3}
+                    direction="row"
+                    justify="center"
+                    style={{ width: "100%", paddingTop: width == "xs" ? "10%" : "" }}
+                >
                     <Grid
                         item
-                        xs={6}
+                        xs={12}
+                        sm={7}
+                        lg={6}
                         style={{
                             display: "flex",
                             flexDirection: "column",
@@ -54,13 +64,20 @@ const Home: NextPage<Props> = ({ events }) => {
                         </CoreTypography>
                         <DDate />
                     </Grid>
-                    <Grid item xs={6} style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-                        <img
-                            src={`/${constants.org.images.logo}`}
-                            alt={`${constants.org.name.short} logo`}
-                            style={{ width: 250 }}
-                        />
-                    </Grid>
+                    {width == "xs" ? null : (
+                        <Grid
+                            item
+                            xs={5}
+                            lg={6}
+                            style={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+                        >
+                            <img
+                                src={`/${constants.org.images.logo}`}
+                                alt={`${constants.org.name.short} logo`}
+                                style={{ width: 250 }}
+                            />
+                        </Grid>
+                    )}
                 </Grid>
             </div>
             <Container disableGutters style={{ marginTop: "-20vh" }}>
@@ -91,4 +108,4 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     }
 }
 
-export default Home;
+export default withWidth()(Home);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,16 +3,53 @@ import { NextPage } from "next";
 import Footer from "src/components/Footer";
 import EventsContainer from "src/components/EventsContainer";
 import Header from "src/components/Header";
-import Date from "src/components/DummyDate";
+import DDate from "src/components/DummyDate";
 import urls from "utils/urls";
+
+import { Event } from "utils/types";
+
+const dummyEvents: Event[] = [
+    {
+        _id: "1",
+        name: "Spring Cleaning",
+        description:
+            "This is going to be super duper duper fun! Oh you want more, do ya? Well, here! This is some more isn't it?? Peeopy ",
+        image: {
+            assetID: "123",
+            url: "https://wallpaperaccess.com/full/3458147.jpg",
+        },
+        location: "123 Butthead Ln",
+        startTime: new Date("12:00 pm"),
+        endTime: new Date("3:00 pm"),
+        startDate: new Date("3/2/21"),
+    },
+    {
+        _id: "2",
+        name: "March Madness, but with cleaning",
+        description: "This is going to be super fun! Not as fun as the last one though.",
+        location: "1021 Francis St",
+        startTime: new Date("12:00 pm"),
+        endTime: new Date("3:00 pm"),
+        startDate: new Date("3/5/21"),
+    },
+    {
+        _id: "3",
+        name: "Test Event w a Long Title like Super Long",
+        description: "This is going to be super fun! Eh not really.",
+        location: "3332 Bikdell St",
+        startTime: new Date("12:00 pm"),
+        endTime: new Date("3:00 pm"),
+        startDate: new Date("3/23/21"),
+    },
+];
 
 const Home: NextPage = () => {
     return (
         <div className="container">
             <Header />
             <div style={{ height: 100 }}>This is the home page with the list of events</div>
-            <Date />
-            <EventsContainer />
+            <DDate />
+            <EventsContainer events={dummyEvents} />
             <Footer />
             <style jsx>{`
                 .container {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,41 +10,63 @@ import { Event } from "utils/types";
 import { useRouter } from "next/router";
 import { getEvents } from "server/actions/Event";
 import constants from "utils/constants";
+import { Button, Container, createStyles, Grid, makeStyles, Theme } from "@material-ui/core";
+import CoreTypography from "src/components/core/typography";
 
 interface Props {
     events: Event[];
 }
 
-const Home: NextPage<Props> = ({ events }) => {
-    return (
-        <div className="container">
-            <Header />
-            <div style={{ height: 100 }}>This is the home page with the list of events</div>
-            <DDate />
-            <EventsContainer events={events} />
-            <Footer />
-            <style jsx>{`
-                .container {
-                    min-height: 100vh;
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                    align-items: center;
-                }
-            `}</style>
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        jumbotron: {
+            width: "100%",
+            height: "65vh",
+            backgroundColor: theme.palette.primary.main,
+            position: "relative",
+            top: 0,
+        },
+    })
+);
 
-            <style jsx global>{`
-                html,
-                body {
-                    padding: 0;
-                    margin: 0;
-                    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell,
-                        Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-                }
-                * {
-                    box-sizing: border-box;
-                }
-            `}</style>
+const Home: NextPage<Props> = ({ events }) => {
+    const classes = useStyles();
+
+    return (
+        <div style={{ width: "100%" }}>
+            <div className={classes.jumbotron}>
+                <Grid container spacing={3} direction="row" justify="center" style={{ width: "100%" }}>
+                    <Grid
+                        item
+                        xs={6}
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            justifyContent: "center",
+                            paddingLeft: "10%",
+                        }}
+                    >
+                        <CoreTypography variant="h1" style={{ color: "white" }}>
+                            Upcoming events
+                        </CoreTypography>
+                        <CoreTypography variant="h3" style={{ fontWeight: "normal", color: "white", marginBottom: 30 }}>
+                            Join us for a workday!
+                        </CoreTypography>
+                        <DDate />
+                    </Grid>
+                    <Grid item xs={6} style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
+                        <img
+                            src={`/${constants.org.images.logo}`}
+                            alt={`${constants.org.name.short} logo`}
+                            style={{ width: 250 }}
+                        />
+                    </Grid>
+                </Grid>
+            </div>
+            <Container disableGutters style={{ marginTop: "-20vh" }}>
+                <EventsContainer events={events} />
+                <Button>Load More</Button>
+            </Container>
         </div>
     );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,15 @@
 import React from "react";
 import { GetStaticPropsContext, NextPage } from "next";
-import Footer from "src/components/Footer";
-import EventsContainer from "src/components/EventsContainer";
-import Header from "src/components/Header";
-import DDate from "src/components/DummyDate";
-import urls from "utils/urls";
-
-import { Event } from "utils/types";
-import { useRouter } from "next/router";
 import withWidth from "@material-ui/core/withWidth";
+
+import { Button, Container, createStyles, Grid, makeStyles, Theme } from "@material-ui/core";
+import EventsContainer from "src/components/EventsContainer";
+import CoreTypography from "src/components/core/typography";
+
 import { getEvents } from "server/actions/Event";
 import constants from "utils/constants";
-import { Button, Container, createStyles, Grid, makeStyles, Theme } from "@material-ui/core";
-import CoreTypography from "src/components/core/typography";
+
+import { Event } from "utils/types";
 
 interface Props {
     events: Event[];
@@ -62,7 +59,6 @@ const Home: NextPage<Props> = ({ events, width }) => {
                         <CoreTypography variant="h3" style={{ fontWeight: "normal", color: "white", marginBottom: 30 }}>
                             Join us for a workday!
                         </CoreTypography>
-                        <DDate />
                     </Grid>
                     {width == "xs" ? null : (
                         <Grid

--- a/tst/components/EventCard.test.tsx
+++ b/tst/components/EventCard.test.tsx
@@ -38,6 +38,7 @@ describe("EventCard.tsx", () => {
     //     console.log(thumbnail.getElement().props);
     // });
 
+    // TODO
     it("handles hover", () => {
         const component = shallow(<EventCard event={evNoImg} />);
     });

--- a/tst/components/EventCard.test.tsx
+++ b/tst/components/EventCard.test.tsx
@@ -29,6 +29,7 @@ describe("EventCard.tsx", () => {
         expect(evTime.children().reduce((acc, cur) => (acc += cur.text()), "")).toBe("12:00 PM - 2:00 PM");
     });
 
+    // probably unneccessary
     // it("renders placeholder when image is missing", () => {
     //     const component = shallow(<EventCard event={evNoImg} />);
 
@@ -37,7 +38,17 @@ describe("EventCard.tsx", () => {
     //     console.log(thumbnail.getElement().props);
     // });
 
-    it("handles hover correctly", () => {
+    it("handles hover", () => {
         const component = shallow(<EventCard event={evNoImg} />);
+    });
+
+    it("interacts with admins on hover", () => {
+        const component = shallow(<EventCard event={evNoImg} />);
+    });
+
+    it("matches snapshot", () => {
+        const component = shallow(<EventCard event={evNoImg} />);
+
+        expect(component).toMatchSnapshot();
     });
 });

--- a/tst/components/EventCard.test.tsx
+++ b/tst/components/EventCard.test.tsx
@@ -1,0 +1,43 @@
+import { shallow } from "enzyme";
+import React, { useState } from "react";
+
+import EventCard from "src/components/EventCard";
+
+import { Event } from "utils/types";
+
+const evNoImg: Event = {
+    name: "Test Event",
+    description: "This is an event with a test description an no image",
+    location: "1200 Baker St Knoxville, TN",
+    startDate: new Date("3/1/21 12:00 pm"),
+    endDate: new Date("3/1/21 2:00 pm"),
+    hours: 2,
+};
+
+describe("EventCard.tsx", () => {
+    it("renders information from event prop correctly", () => {
+        const component = shallow(<EventCard event={evNoImg} />);
+
+        const evName = component.find("#eventName");
+        const evDesc = component.find("#eventDesc");
+        const evLoc = component.find("#eventLoc");
+        const evTime = component.find("#eventTime");
+
+        expect(evName.children().text()).toBe(evNoImg.name);
+        expect(evDesc.children().text()).toBe(evNoImg.description);
+        expect(evLoc.children().text()).toBe(evNoImg.location?.split(",")[0]);
+        expect(evTime.children().reduce((acc, cur) => (acc += cur.text()), "")).toBe("12:00 PM - 2:00 PM");
+    });
+
+    // it("renders placeholder when image is missing", () => {
+    //     const component = shallow(<EventCard event={evNoImg} />);
+
+    //     const thumbnail = component.find("#eventThumb");
+
+    //     console.log(thumbnail.getElement().props);
+    // });
+
+    it("handles hover correctly", () => {
+        const component = shallow(<EventCard event={evNoImg} />);
+    });
+});

--- a/tst/components/__snapshots__/EventCard.test.tsx.snap
+++ b/tst/components/__snapshots__/EventCard.test.tsx.snap
@@ -1,0 +1,168 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventCard.tsx matches snapshot 1`] = `
+<div>
+  <WithStyles(ForwardRef(Card))
+    className="makeStyles-eventCard-1"
+    elevation={7}
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <EventThumbnail
+      localHover={false}
+    >
+      <Styled(MuiBox)
+        className="makeStyles-eventDate-6"
+      >
+        <span>
+          <CoreTypography
+            style={
+              Object {
+                "marginBottom": 0,
+                "textTransform": "uppercase",
+              }
+            }
+            variant="h5"
+          >
+            Mar
+          </CoreTypography>
+          <CoreTypography
+            style={
+              Object {
+                "fontSize": "1.75em",
+                "lineHeight": "20px",
+                "marginBottom": 0,
+              }
+            }
+            variant="h3"
+          >
+            1
+          </CoreTypography>
+        </span>
+      </Styled(MuiBox)>
+    </EventThumbnail>
+    <WithStyles(ForwardRef(CardContent))>
+      <div
+        style={
+          Object {
+            "height": 105,
+            "overflow": "hidden",
+          }
+        }
+      >
+        <CoreTypography
+          className="makeStyles-title-7"
+          gutterBottom={true}
+          id="eventName"
+          variant="h3"
+        >
+          Test Event
+        </CoreTypography>
+        <CoreTypography
+          id="eventDesc"
+          style={
+            Object {
+              "color": "rgba(0,0,0,.4)",
+              "fontFamily": "Ubuntu",
+            }
+          }
+          variant="body2"
+        >
+          This is an event with a test description an no image
+        </CoreTypography>
+      </div>
+      <WithStyles(ForwardRef(Grid))
+        alignItems="center"
+        container={true}
+        justify="center"
+        spacing={1}
+        wrap="nowrap"
+      >
+        <Memo([object Object])
+          color="primary"
+        />
+        <WithStyles(ForwardRef(Grid))
+          item={true}
+          style={
+            Object {
+              "alignItems": "center",
+              "display": "flex",
+            }
+          }
+          xs={6}
+        >
+          <CoreTypography
+            component="p"
+            id="eventLoc"
+            style={
+              Object {
+                "color": "#F298AE",
+                "fontFamily": "Ubuntu",
+                "fontSize": 13,
+                "fontWeight": 600,
+                "overflow": "hidden",
+                "textOverflow": "ellipsis",
+                "whiteSpace": "nowrap",
+              }
+            }
+            variant="caption"
+          >
+            1200 Baker St Knoxville
+          </CoreTypography>
+        </WithStyles(ForwardRef(Grid))>
+        <Memo([object Object])
+          color="primary"
+        />
+        <WithStyles(ForwardRef(Grid))
+          item={true}
+          xs={5}
+        >
+          <CoreTypography
+            component="p"
+            id="eventTime"
+            style={
+              Object {
+                "color": "#F298AE",
+                "fontFamily": "Ubuntu",
+                "fontSize": 13,
+                "fontWeight": 600,
+                "overflow": "hidden",
+                "textOverflow": "ellipsis",
+                "whiteSpace": "nowrap",
+              }
+            }
+            variant="caption"
+          >
+            12:00 PM
+             - 
+            2:00 PM
+          </CoreTypography>
+        </WithStyles(ForwardRef(Grid))>
+      </WithStyles(ForwardRef(Grid))>
+    </WithStyles(ForwardRef(CardContent))>
+  </WithStyles(ForwardRef(Card))>
+  <WithStyles(ForwardRef(Menu))
+    anchorEl={null}
+    id="simple-menu"
+    keepMounted={true}
+    open={false}
+  >
+    <WithStyles(ForwardRef(MenuItem))
+      onClick={[Function]}
+    >
+      Edit
+    </WithStyles(ForwardRef(MenuItem))>
+    <WithStyles(ForwardRef(MenuItem))
+      onClick={[Function]}
+    >
+      Manage
+    </WithStyles(ForwardRef(MenuItem))>
+    <WithStyles(ForwardRef(MenuItem))
+      onClick={[Function]}
+    >
+      Delete
+    </WithStyles(ForwardRef(MenuItem))>
+  </WithStyles(ForwardRef(Menu))>
+</div>
+`;


### PR DESCRIPTION
This PR creates the MVP for the `EventCard` component. I wrote a couple initial tests for the component, but there are still a couple things that could be tested. The `EventCard` component **must** have an `event` prop and can also contain an optional `isAdmin` prop which will be used to show the 'more' dots on the admin pages. There is some weirdness in how the description gets cut off, but I think I can figure out a solution before we ship.

Another thing, I mentioned this in Slack, but I decided to move the `Header` and `Footer` components into `_app.tsx` in order to DRY up the code and make it easier to scaffold pages.

While working on this task, I also started to work on the upcoming events page, but I will finish that in a separate branch. Images below

![upcoming events page with eventcard component](https://user-images.githubusercontent.com/17971951/109526526-a1917880-7a80-11eb-98a9-8acdcaf640ce.png)
