### PR TITLE
Rossketron kkb 46 volunteer profiles events frontend component

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dependencies": {
         "@material-ui/core": "^4.11.3",
         "@material-ui/icons": "^4.11.2",
+        "@material-ui/lab": "^4.0.0-alpha.57",
         "@types/formidable": "^1.0.32",
         "@types/mongoose": "^5.10.3",
         "date-fns": "^2.0.0-beta.5",

--- a/server/models/Volunteer.ts
+++ b/server/models/Volunteer.ts
@@ -31,4 +31,4 @@ export const VolunteerSchema = new Schema({
 
 export interface VolunteerDocument extends Omit<Volunteer, "_id">, Document {}
 
-export default (models.User as Model<VolunteerDocument>) || model<VolunteerDocument>("Volunteer", VolunteerSchema);
+export default (models.Volunteer as Model<VolunteerDocument>) || model<VolunteerDocument>("Volunteer", VolunteerSchema);

--- a/src/components/VolunteerEventsList/index.tsx
+++ b/src/components/VolunteerEventsList/index.tsx
@@ -1,17 +1,87 @@
-import React from "react";
+import React, { useState } from "react";
 import constants from "utils/constants";
 import CoreTypography from "src/components/core/typography/CoreTypography";
 import colors from "src/components/core/colors";
-import { createStyles, makeStyles, Theme, withStyles } from "@material-ui/core/styles";
+import { createStyles, makeStyles, Theme, useTheme, withStyles } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
+import TableFooter from "@material-ui/core/TableFooter";
 import Paper from "@material-ui/core/Paper";
 import SortIcon from "@material-ui/icons/Sort";
 import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+import TablePagination from "@material-ui/core/TablePagination";
+import IconButton from "@material-ui/core/IconButton";
+import FirstPageIcon from "@material-ui/icons/FirstPage";
+import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft";
+import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight";
+import LastPageIcon from "@material-ui/icons/LastPage";
+
+const useStyles1 = makeStyles((theme: Theme) =>
+    createStyles({
+        root: {
+            flexShrink: 0,
+            marginLeft: theme.spacing(2.5),
+        },
+    })
+);
+
+interface TablePaginationActionsProps {
+    count: number;
+    page: number;
+    rowsPerPage: number;
+    onChangePage: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void;
+}
+
+function TablePaginationActions(props: TablePaginationActionsProps) {
+    const classes = useStyles1();
+    const theme = useTheme();
+    const { count, page, rowsPerPage, onChangePage } = props;
+
+    const handleFirstPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        onChangePage(event, 0);
+    };
+
+    const handleBackButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        onChangePage(event, page - 1);
+    };
+
+    const handleNextButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        onChangePage(event, page + 1);
+    };
+
+    const handleLastPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        onChangePage(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1));
+    };
+
+    return (
+        <div className={classes.root}>
+            <IconButton onClick={handleFirstPageButtonClick} disabled={page === 0} aria-label="first page">
+                {theme.direction === "rtl" ? <LastPageIcon /> : <FirstPageIcon />}
+            </IconButton>
+            <IconButton onClick={handleBackButtonClick} disabled={page === 0} aria-label="previous page">
+                {theme.direction === "rtl" ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+            </IconButton>
+            <IconButton
+                onClick={handleNextButtonClick}
+                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+                aria-label="next page"
+            >
+                {theme.direction === "rtl" ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+            </IconButton>
+            <IconButton
+                onClick={handleLastPageButtonClick}
+                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+                aria-label="last page"
+            >
+                {theme.direction === "rtl" ? <FirstPageIcon /> : <LastPageIcon />}
+            </IconButton>
+        </div>
+    );
+}
 
 const StyledTableCell = withStyles((theme: Theme) =>
     createStyles({
@@ -56,16 +126,41 @@ function createData(eventName: string, date: Date, hours: number) {
 
 const rows = [
     createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
-    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-15"), 4),
-    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-15"), 3),
+    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-16"), 4),
+    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-12"), 3),
+    createData("February Saturday Spruce Up 2", new Date("2021-02-05"), 2),
+    createData("2021 North Knoxville Community Clean Up 2", new Date("2021-02-15"), 1),
+    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
+    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
+    createData("January Saturday Spruce Up", new Date("2021-01-10"), 1),
+    createData("2020 North Knoxville Community Clean Up", new Date("2020-02-16"), 4),
+    createData("Keep the Little River Beautiful Knoxville Clean Up", new Date("2020-04-12"), 3),
+    createData("February Saturday Spruce Up 5", new Date("2021-02-05"), 2),
+    createData("2021 South Knoxville Community Clean Up", new Date("2021-03-1"), 1),
+    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
+    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
     createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
-    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-15"), 1),
-    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-15"), 2),
-    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
+    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-16"), 4),
+    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-12"), 3),
+    createData("February Saturday Spruce Up 2", new Date("2021-02-05"), 2),
+    createData("2021 North Knoxville Community Clean Up 2", new Date("2021-02-15"), 1),
+    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
+    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
 ];
 
 export default function VolunteerEventsList() {
     const classes = useStyles();
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(5);
+
+    const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
+        setPage(newPage);
+    };
+
+    const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        setRowsPerPage(parseInt(event.target.value, 10));
+        setPage(0);
+    };
 
     return (
         <TableContainer component={Paper} className={classes.tableContainer}>
@@ -90,37 +185,48 @@ export default function VolunteerEventsList() {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {rows.map(row => (
-                        <TableRow key={row.eventName} className={classes.eventRow}>
-                            <TableCell component="th" scope="row">
-                                <CoreTypography variant="body2">{row.eventName}</CoreTypography>
-                            </TableCell>
-                            <TableCell align="center">
-                                <CoreTypography variant="body2">
-                                    {row.date.toLocaleDateString("en-us", {
-                                        month: "2-digit",
-                                        day: "2-digit",
-                                        year: "numeric",
-                                    })}
-                                </CoreTypography>
-                            </TableCell>
-                            <TableCell align="center">
-                                <CoreTypography variant="body2">{row.hours}</CoreTypography>
-                            </TableCell>
-                        </TableRow>
-                    ))}
+                    {(rowsPerPage > 0 ? rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage) : rows).map(
+                        row => (
+                            <TableRow key={row.eventName} className={classes.eventRow}>
+                                <TableCell component="th" scope="row">
+                                    <CoreTypography variant="body2">{row.eventName}</CoreTypography>
+                                </TableCell>
+                                <TableCell align="center">
+                                    <CoreTypography variant="body2">
+                                        {row.date.toLocaleDateString("en-us", {
+                                            month: "2-digit",
+                                            day: "2-digit",
+                                            year: "numeric",
+                                        })}
+                                    </CoreTypography>
+                                </TableCell>
+                                <TableCell align="center">
+                                    <CoreTypography variant="body2">{row.hours}</CoreTypography>
+                                </TableCell>
+                            </TableRow>
+                        )
+                    )}
                 </TableBody>
             </Table>
             <div className={classes.tableFooter}>
                 <div />
                 <div>
-                    <CoreTypography variant="subtitle1">12</CoreTypography>
+                    <TablePagination
+                        rowsPerPageOptions={[5, 10, 25, { label: "All", value: -1 }]}
+                        colSpan={3}
+                        count={rows.length}
+                        rowsPerPage={rowsPerPage}
+                        page={page}
+                        SelectProps={{
+                            inputProps: { "aria-label": "rows per page" },
+                            native: true,
+                        }}
+                        onChangePage={handleChangePage}
+                        onChangeRowsPerPage={handleChangeRowsPerPage}
+                        ActionsComponent={TablePaginationActions}
+                    />
                 </div>
-                <div>
-                    <button className={classes.pageArrow}>
-                        <ArrowRightAltIcon />
-                    </button>
-                </div>
+                <div />
             </div>
         </TableContainer>
     );

--- a/src/components/VolunteerEventsList/index.tsx
+++ b/src/components/VolunteerEventsList/index.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import constants from "utils/constants";
+import CoreTypography from "src/components/core/typography/CoreTypography";
+import colors from "src/components/core/colors";
+import { createStyles, makeStyles, Theme, withStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import SortIcon from "@material-ui/icons/Sort";
+import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+
+const StyledTableCell = withStyles((theme: Theme) =>
+    createStyles({
+        head: {
+            backgroundColor: theme.palette.primary.light,
+            color: theme.palette.text.primary,
+            padding: "10px",
+            verticalAlign: "middle",
+        },
+    })
+)(TableCell);
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        tableContainer: {
+            border: `1px solid ${theme.palette.primary.light}`,
+            minWidth: "300px",
+            padding: "10px 8px",
+            backgroundColor: colors.white,
+        },
+        eventRow: {
+            borderBottom: `2px solid ${theme.palette.text.secondary}`,
+        },
+        tableFooter: {
+            marginTop: "45px",
+            height: "35px",
+            width: "100%",
+            display: "flex",
+            alignItems: "end",
+            justifyContent: "space-between",
+        },
+        pageArrow: {
+            background: "none",
+            border: "none",
+        },
+    })
+);
+
+function createData(eventName: string, date: Date, hours: number) {
+    return { eventName, date, hours };
+}
+
+const rows = [
+    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
+    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-15"), 4),
+    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-15"), 3),
+    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
+    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-15"), 1),
+    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-15"), 2),
+    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
+];
+
+export default function VolunteerEventsList() {
+    const classes = useStyles();
+
+    return (
+        <TableContainer component={Paper} className={classes.tableContainer}>
+            <Table aria-label="simple table">
+                <TableHead>
+                    <TableRow>
+                        <StyledTableCell>
+                            <CoreTypography variant="h4">
+                                Event Name&nbsp;&nbsp;
+                                <SortIcon style={{ verticalAlign: "middle" }} />
+                            </CoreTypography>
+                        </StyledTableCell>
+                        <StyledTableCell align="center">
+                            <CoreTypography variant="h4">Date</CoreTypography>
+                        </StyledTableCell>
+                        <StyledTableCell>
+                            <CoreTypography variant="h4" style={{ textAlign: "center" }}>
+                                Hours&nbsp;&nbsp;
+                                <SortIcon style={{ verticalAlign: "middle" }} />
+                            </CoreTypography>
+                        </StyledTableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {rows.map(row => (
+                        <TableRow key={row.eventName} className={classes.eventRow}>
+                            <TableCell component="th" scope="row">
+                                <CoreTypography variant="body2">{row.eventName}</CoreTypography>
+                            </TableCell>
+                            <TableCell align="center">
+                                <CoreTypography variant="body2">
+                                    {row.date.toLocaleDateString("en-us", {
+                                        month: "2-digit",
+                                        day: "2-digit",
+                                        year: "numeric",
+                                    })}
+                                </CoreTypography>
+                            </TableCell>
+                            <TableCell align="center">
+                                <CoreTypography variant="body2">{row.hours}</CoreTypography>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+            <div className={classes.tableFooter}>
+                <div />
+                <div>
+                    <CoreTypography variant="subtitle1">12</CoreTypography>
+                </div>
+                <div>
+                    <button className={classes.pageArrow}>
+                        <ArrowRightAltIcon />
+                    </button>
+                </div>
+            </div>
+        </TableContainer>
+    );
+}

--- a/src/components/VolunteerEventsList/index.tsx
+++ b/src/components/VolunteerEventsList/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Event, Volunteer } from "utils/types";
 import CoreTypography from "src/components/core/typography/CoreTypography";
 import colors from "src/components/core/colors";
-import { createStyles, makeStyles, Theme, useTheme, withStyles } from "@material-ui/core/styles";
+import { createStyles, makeStyles, Theme, withStyles } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
@@ -11,78 +11,7 @@ import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import Paper from "@material-ui/core/Paper";
 import SortIcon from "@material-ui/icons/Sort";
-import TablePagination from "@material-ui/core/TablePagination";
-import IconButton from "@material-ui/core/IconButton";
-import FirstPageIcon from "@material-ui/icons/FirstPage";
-import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft";
-import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight";
-import LastPageIcon from "@material-ui/icons/LastPage";
-
-// create styles for table pagination footer
-const useStyles1 = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            flexShrink: 0,
-            marginLeft: theme.spacing(2.5),
-        },
-    })
-);
-
-// create props for table pagination
-interface TablePaginationActionsProps {
-    count: number;
-    page: number;
-    rowsPerPage: number;
-    onChangePage: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void;
-}
-
-// create table pagination actions and first, prev, next, last page buttons
-function TablePaginationActions(props: TablePaginationActionsProps) {
-    const classes = useStyles1();
-    const theme = useTheme();
-    const { count, page, rowsPerPage, onChangePage } = props;
-
-    const handleFirstPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-        onChangePage(event, 0);
-    };
-
-    const handleBackButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-        onChangePage(event, page - 1);
-    };
-
-    const handleNextButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-        onChangePage(event, page + 1);
-    };
-
-    const handleLastPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-        onChangePage(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1));
-    };
-
-    return (
-        <div className={classes.root}>
-            <IconButton onClick={handleFirstPageButtonClick} disabled={page === 0} aria-label="first page">
-                {theme.direction === "rtl" ? <LastPageIcon /> : <FirstPageIcon />}
-            </IconButton>
-            <IconButton onClick={handleBackButtonClick} disabled={page === 0} aria-label="previous page">
-                {theme.direction === "rtl" ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
-            </IconButton>
-            <IconButton
-                onClick={handleNextButtonClick}
-                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-                aria-label="next page"
-            >
-                {theme.direction === "rtl" ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
-            </IconButton>
-            <IconButton
-                onClick={handleLastPageButtonClick}
-                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-                aria-label="last page"
-            >
-                {theme.direction === "rtl" ? <FirstPageIcon /> : <LastPageIcon />}
-            </IconButton>
-        </div>
-    );
-}
+import Pagination from "@material-ui/lab/Pagination";
 
 // style attended event table header row cells
 const StyledTableCell = withStyles((theme: Theme) =>
@@ -155,20 +84,17 @@ const rows = [
 // create attended events table for current volunteer
 export default function VolunteerEventsList(props: Volunteer) {
     const classes = useStyles();
-    const [page, setPage] = useState(0);
-    const [rowsPerPage, setRowsPerPage] = useState(5);
+    const eventsPerPage = 5;
+    const [page, setPage] = useState(1);
 
-    // Uncomment to use actual volunteer data for volId from server
-    // const rows: Array<Event> = props.attendedEvents ? props.attendedEvents : [];
-
-    const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
+    const handleChange = (event: React.ChangeEvent<unknown>, newPage: number) => {
         setPage(newPage);
     };
 
-    const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        setRowsPerPage(parseInt(event.target.value, 10));
-        setPage(0);
-    };
+    // Uncomment to use actual volunteer data for volId from server
+    //const rows: Array<Event> = props.attendedEvents ? props.attendedEvents : [];
+
+    const numPages = rows.length > 0 ? Math.ceil(rows.length / eventsPerPage) : 0;
 
     return (
         <TableContainer component={Paper} className={classes.tableContainer}>
@@ -193,46 +119,34 @@ export default function VolunteerEventsList(props: Volunteer) {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {(rowsPerPage > 0 ? rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage) : rows).map(
-                        row => (
-                            <TableRow key={row.name} className={classes.eventRow}>
-                                <TableCell component="th" scope="row">
-                                    <CoreTypography variant="body2">{row.name}</CoreTypography>
-                                </TableCell>
-                                <TableCell align="center">
-                                    <CoreTypography variant="body2">
-                                        {row.endDate?.toLocaleDateString("en-us", {
-                                            month: "2-digit",
-                                            day: "2-digit",
-                                            year: "numeric",
-                                        })}
-                                    </CoreTypography>
-                                </TableCell>
-                                <TableCell align="center">
-                                    <CoreTypography variant="body2">{row.hours}</CoreTypography>
-                                </TableCell>
-                            </TableRow>
-                        )
-                    )}
+                    {(numPages > 0
+                        ? rows.slice((page - 1) * eventsPerPage, (page - 1) * eventsPerPage + eventsPerPage)
+                        : rows
+                    ).map(row => (
+                        <TableRow key={row.name} className={classes.eventRow}>
+                            <TableCell component="th" scope="row">
+                                <CoreTypography variant="body2">{row.name}</CoreTypography>
+                            </TableCell>
+                            <TableCell align="center">
+                                <CoreTypography variant="body2">
+                                    {row.endDate?.toLocaleDateString("en-us", {
+                                        month: "2-digit",
+                                        day: "2-digit",
+                                        year: "numeric",
+                                    })}
+                                </CoreTypography>
+                            </TableCell>
+                            <TableCell align="center">
+                                <CoreTypography variant="body2">{row.hours}</CoreTypography>
+                            </TableCell>
+                        </TableRow>
+                    ))}
                 </TableBody>
             </Table>
             <div className={classes.tableFooter}>
                 <div />
                 <div>
-                    <TablePagination
-                        rowsPerPageOptions={[5, 10, 25, { label: "All", value: -1 }]}
-                        colSpan={3}
-                        count={rows.length}
-                        rowsPerPage={rowsPerPage}
-                        page={page}
-                        SelectProps={{
-                            inputProps: { "aria-label": "rows per page" },
-                            native: true,
-                        }}
-                        onChangePage={handleChangePage}
-                        onChangeRowsPerPage={handleChangeRowsPerPage}
-                        ActionsComponent={TablePaginationActions}
-                    />
+                    <Pagination count={numPages} page={page} onChange={handleChange} />
                 </div>
                 <div />
             </div>

--- a/src/components/VolunteerEventsList/index.tsx
+++ b/src/components/VolunteerEventsList/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import constants from "utils/constants";
+import { Event, Volunteer } from "utils/types";
 import CoreTypography from "src/components/core/typography/CoreTypography";
 import colors from "src/components/core/colors";
 import { createStyles, makeStyles, Theme, useTheme, withStyles } from "@material-ui/core/styles";
@@ -9,10 +9,8 @@ import TableCell from "@material-ui/core/TableCell";
 import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
-import TableFooter from "@material-ui/core/TableFooter";
 import Paper from "@material-ui/core/Paper";
 import SortIcon from "@material-ui/icons/Sort";
-import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
 import TablePagination from "@material-ui/core/TablePagination";
 import IconButton from "@material-ui/core/IconButton";
 import FirstPageIcon from "@material-ui/icons/FirstPage";
@@ -20,6 +18,7 @@ import KeyboardArrowLeft from "@material-ui/icons/KeyboardArrowLeft";
 import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight";
 import LastPageIcon from "@material-ui/icons/LastPage";
 
+// create styles for table pagination footer
 const useStyles1 = makeStyles((theme: Theme) =>
     createStyles({
         root: {
@@ -29,6 +28,7 @@ const useStyles1 = makeStyles((theme: Theme) =>
     })
 );
 
+// create props for table pagination
 interface TablePaginationActionsProps {
     count: number;
     page: number;
@@ -36,6 +36,7 @@ interface TablePaginationActionsProps {
     onChangePage: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void;
 }
 
+// create table pagination actions and first, prev, next, last page buttons
 function TablePaginationActions(props: TablePaginationActionsProps) {
     const classes = useStyles1();
     const theme = useTheme();
@@ -83,6 +84,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
     );
 }
 
+// style attended event table header row cells
 const StyledTableCell = withStyles((theme: Theme) =>
     createStyles({
         head: {
@@ -94,6 +96,7 @@ const StyledTableCell = withStyles((theme: Theme) =>
     })
 )(TableCell);
 
+// style attended event table container and cells
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         tableContainer: {
@@ -120,8 +123,9 @@ const useStyles = makeStyles((theme: Theme) =>
     })
 );
 
-function createData(eventName: string, date: Date, hours: number) {
-    return { eventName, date, hours };
+// create dummy data for design purposes -- comment out to use volId data
+function createData(name: string, endDate: Date, hours: number) {
+    return { name, endDate, hours };
 }
 
 const rows = [
@@ -148,10 +152,14 @@ const rows = [
     createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
 ];
 
-export default function VolunteerEventsList() {
+// create attended events table for current volunteer
+export default function VolunteerEventsList(props: Volunteer) {
     const classes = useStyles();
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(5);
+
+    // Uncomment to use actual volunteer data for volId from server
+    // const rows: Array<Event> = props.attendedEvents ? props.attendedEvents : [];
 
     const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
         setPage(newPage);
@@ -187,13 +195,13 @@ export default function VolunteerEventsList() {
                 <TableBody>
                     {(rowsPerPage > 0 ? rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage) : rows).map(
                         row => (
-                            <TableRow key={row.eventName} className={classes.eventRow}>
+                            <TableRow key={row.name} className={classes.eventRow}>
                                 <TableCell component="th" scope="row">
-                                    <CoreTypography variant="body2">{row.eventName}</CoreTypography>
+                                    <CoreTypography variant="body2">{row.name}</CoreTypography>
                                 </TableCell>
                                 <TableCell align="center">
                                     <CoreTypography variant="body2">
-                                        {row.date.toLocaleDateString("en-us", {
+                                        {row.endDate?.toLocaleDateString("en-us", {
                                             month: "2-digit",
                                             day: "2-digit",
                                             year: "numeric",

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -3,16 +3,11 @@ import VolunteerEventsList from "../../components/VolunteerEventsList";
 import Header from "src/components/Header";
 import Footer from "src/components/Footer";
 import { getVolunteer } from "server/actions/Volunteer";
-import { Event, Volunteer } from "utils/types";
+import { Volunteer } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";
 import Error from "next/error";
 import constants from "utils/constants";
-import CoreTypography from "src/components/core/typography/CoreTypography";
-import colors from "src/components/core/colors";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
-import Card from "@material-ui/core/Card";
-import Container from "@material-ui/core/Container";
-import CardContent from "@material-ui/core/CardContent";
 
 interface Props {
     vol: Volunteer;
@@ -29,18 +24,21 @@ const useStyles = makeStyles((theme: Theme) =>
 const VolunteerPage: NextPage<Props> = ({ vol }) => {
     const classes = useStyles();
 
+    if (!vol) {
+        return <Error statusCode={404} />;
+    }
     return (
         <>
             <Header />
             <div className={classes.container}>
-                <VolunteerEventsList />
+                <VolunteerEventsList {...vol} />
             </div>
             <Footer />
         </>
     );
 };
 
-// query data and pass it to component here. this is run server-side
+// get volunteer data
 export async function getStaticProps(context: GetStaticPropsContext) {
     try {
         console.log(context.params?.volId);
@@ -60,7 +58,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     }
 }
 
-// required for dynamic pages: prerender events at build time
+// required for dynamic pages: prerender volunteers at build time
 export async function getStaticPaths() {
     const volunteers: Volunteer[] = []; //await getVolunteers({});
 

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import VolunteerEventsList from "../../components/VolunteerEventsList";
+import Header from "src/components/Header";
+import Footer from "src/components/Footer";
+import { getVolunteer } from "server/actions/Volunteer";
+import { Event, Volunteer } from "utils/types";
+import { GetStaticPropsContext, NextPage } from "next";
+import Error from "next/error";
+import constants from "utils/constants";
+import CoreTypography from "src/components/core/typography/CoreTypography";
+import colors from "src/components/core/colors";
+import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import Card from "@material-ui/core/Card";
+import Container from "@material-ui/core/Container";
+import CardContent from "@material-ui/core/CardContent";
+
+interface Props {
+    vol: Volunteer;
+}
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        container: {
+            margin: "50px",
+        },
+    })
+);
+
+const VolunteerPage: NextPage<Props> = ({ vol }) => {
+    const classes = useStyles();
+
+    return (
+        <>
+            <Header />
+            <div className={classes.container}>
+                <VolunteerEventsList />
+            </div>
+            <Footer />
+        </>
+    );
+};
+
+// query data and pass it to component here. this is run server-side
+export async function getStaticProps(context: GetStaticPropsContext) {
+    try {
+        console.log(context.params?.volId);
+        const vol: Volunteer = await getVolunteer(context.params?.volId as string);
+
+        return {
+            props: {
+                vol: JSON.parse(JSON.stringify(vol)) as Volunteer,
+            },
+            revalidate: constants.revalidate.volunteerProfile,
+        };
+    } catch (error) {
+        return {
+            props: {},
+            revalidate: constants.revalidate.volunteerProfile,
+        };
+    }
+}
+
+// required for dynamic pages: prerender events at build time
+export async function getStaticPaths() {
+    const volunteers: Volunteer[] = []; //await getVolunteers({});
+
+    const paths = volunteers.map(volunteer => ({
+        params: { name: volunteer._id },
+    }));
+
+    return { paths, fallback: true };
+}
+
+export default VolunteerPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,6 +1234,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.57":
+  version "4.0.0-alpha.57"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz#e8961bcf6449e8a8dabe84f2700daacfcafbf83a"
+  integrity sha512-qo/IuIQOmEKtzmRD2E4Aa6DB4A87kmY6h0uYhjUmrrgmEAgbbw9etXpWPVXuRK6AGIQCjFzV6WO2i21m1R4FCw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
 "@material-ui/styles@^4.11.3":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"


### PR DESCRIPTION
This PR implements the volunteer attendedEvents list on a single volunteer page. I created dummy data to use for design purposes, but I also added functionality to use the volId data from server. I used material-ui table and pagination features to create the list. There are features for choosing the number of events to display on a page as well as buttons for first page, last page, previous page, and next page. The pagination design is slightly different from the figma mock-up, but I can try to change it if you all think it would look better. 

I have not added sorting functionality yet, and I have not been able to create tests yet. 

Here are a couple of screenshots of the events list with 5 events/page selected and a display of a volunteer with no attended events.

<img width="1278" alt="Screen Shot 2021-03-06 at 2 36 21 PM" src="https://user-images.githubusercontent.com/58822572/110219823-73040b00-7e8f-11eb-923d-936aedc7a47b.png">

<img width="642" alt="Screen Shot 2021-03-06 at 2 35 51 PM" src="https://user-images.githubusercontent.com/58822572/110219825-75666500-7e8f-11eb-9c7b-9003b598c76d.png">
