### PR TITLE
Volunteer profile page - frontend

### DIFF
--- a/src/components/VolunteerEventsList/index.tsx
+++ b/src/components/VolunteerEventsList/index.tsx
@@ -13,73 +13,6 @@ import Paper from "@material-ui/core/Paper";
 import SortIcon from "@material-ui/icons/Sort";
 import Pagination from "@material-ui/lab/Pagination";
 
-// style attended event table header row cells
-const StyledTableCell = withStyles((theme: Theme) =>
-    createStyles({
-        head: {
-            backgroundColor: theme.palette.primary.light,
-            color: theme.palette.text.primary,
-            padding: "10px",
-            verticalAlign: "middle",
-        },
-    })
-)(TableCell);
-
-// style attended event table container and cells
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        tableContainer: {
-            border: `1px solid ${theme.palette.primary.light}`,
-            width: "90vw",
-            minWidth: "300px",
-            maxWidth: "1400px",
-            minHeight: "450px",
-            padding: "10px 8px",
-            backgroundColor: colors.white,
-        },
-        eventRow: {
-            borderBottom: `2px solid ${theme.palette.text.secondary}`,
-        },
-        tableFooter: {
-            marginTop: "45px",
-            height: "35px",
-            width: "100%",
-            display: "flex",
-            alignItems: "end",
-            justifyContent: "space-between",
-        },
-    })
-);
-
-// create dummy data for design purposes -- comment out to use volId data
-function createData(name: string, endDate: Date, hours: number) {
-    return { name, endDate, hours };
-}
-
-const rows = [
-    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
-    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-16"), 4),
-    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-12"), 3),
-    createData("February Saturday Spruce Up 2", new Date("2021-02-05"), 2),
-    createData("2021 North Knoxville Community Clean Up 2", new Date("2021-02-15"), 1),
-    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
-    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
-    createData("January Saturday Spruce Up", new Date("2021-01-10"), 1),
-    createData("2020 North Knoxville Community Clean Up", new Date("2020-02-16"), 4),
-    createData("Keep the Little River Beautiful Knoxville Clean Up", new Date("2020-04-12"), 3),
-    createData("February Saturday Spruce Up 5", new Date("2021-02-05"), 2),
-    createData("2021 South Knoxville Community Clean Up", new Date("2021-03-1"), 1),
-    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
-    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
-    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
-    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-16"), 4),
-    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-12"), 3),
-    createData("February Saturday Spruce Up 2", new Date("2021-02-05"), 2),
-    createData("2021 North Knoxville Community Clean Up 2", new Date("2021-02-15"), 1),
-    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
-    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
-];
-
 // create attended events table for current volunteer
 export default function VolunteerEventsList(props: Volunteer) {
     const classes = useStyles();
@@ -171,3 +104,70 @@ export default function VolunteerEventsList(props: Volunteer) {
         </TableContainer>
     );
 }
+
+// style attended event table header row cells
+const StyledTableCell = withStyles((theme: Theme) =>
+    createStyles({
+        head: {
+            backgroundColor: theme.palette.primary.light,
+            color: theme.palette.text.primary,
+            padding: "10px",
+            verticalAlign: "middle",
+        },
+    })
+)(TableCell);
+
+// style attended event table container and cells
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        tableContainer: {
+            border: `1px solid ${theme.palette.primary.light}`,
+            width: "90vw",
+            minWidth: "300px",
+            maxWidth: "1400px",
+            minHeight: "450px",
+            padding: "10px 8px",
+            backgroundColor: colors.white,
+        },
+        eventRow: {
+            borderBottom: `2px solid ${theme.palette.text.secondary}`,
+        },
+        tableFooter: {
+            marginTop: "45px",
+            height: "35px",
+            width: "100%",
+            display: "flex",
+            alignItems: "end",
+            justifyContent: "space-between",
+        },
+    })
+);
+
+// create dummy data for design purposes -- comment out to use volId data
+function createData(name: string, endDate: Date, hours: number) {
+    return { name, endDate, hours };
+}
+
+const rows = [
+    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
+    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-16"), 4),
+    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-12"), 3),
+    createData("February Saturday Spruce Up 2", new Date("2021-02-05"), 2),
+    createData("2021 North Knoxville Community Clean Up 2", new Date("2021-02-15"), 1),
+    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
+    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
+    createData("January Saturday Spruce Up", new Date("2021-01-10"), 1),
+    createData("2020 North Knoxville Community Clean Up", new Date("2020-02-16"), 4),
+    createData("Keep the Little River Beautiful Knoxville Clean Up", new Date("2020-04-12"), 3),
+    createData("February Saturday Spruce Up 5", new Date("2021-02-05"), 2),
+    createData("2021 South Knoxville Community Clean Up", new Date("2021-03-1"), 1),
+    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
+    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
+    createData("February Saturday Spruce Up", new Date("2021-02-15"), 2),
+    createData("2021 North Knoxville Community Clean Up", new Date("2021-02-16"), 4),
+    createData("Keep the TN River Beautiful Knoxville Clean Up", new Date("2021-02-12"), 3),
+    createData("February Saturday Spruce Up 2", new Date("2021-02-05"), 2),
+    createData("2021 North Knoxville Community Clean Up 2", new Date("2021-02-15"), 1),
+    createData("Keep the TN River Beautiful Knoxville Clean Up 2", new Date("2021-02-22"), 2),
+    createData("February Saturday Spruce Up 3", new Date("2021-02-20"), 2),
+];

--- a/src/components/VolunteerEventsList/index.tsx
+++ b/src/components/VolunteerEventsList/index.tsx
@@ -30,7 +30,10 @@ const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         tableContainer: {
             border: `1px solid ${theme.palette.primary.light}`,
+            width: "90vw",
             minWidth: "300px",
+            maxWidth: "1400px",
+            minHeight: "450px",
             padding: "10px 8px",
             backgroundColor: colors.white,
         },
@@ -44,10 +47,6 @@ const useStyles = makeStyles((theme: Theme) =>
             display: "flex",
             alignItems: "end",
             justifyContent: "space-between",
-        },
-        pageArrow: {
-            background: "none",
-            border: "none",
         },
     })
 );
@@ -95,6 +94,7 @@ export default function VolunteerEventsList(props: Volunteer) {
     //const rows: Array<Event> = props.attendedEvents ? props.attendedEvents : [];
 
     const numPages = rows.length > 0 ? Math.ceil(rows.length / eventsPerPage) : 0;
+    const emptyRows = numPages > 0 ? numPages * eventsPerPage - rows.length : eventsPerPage;
 
     return (
         <TableContainer component={Paper} className={classes.tableContainer}>
@@ -119,28 +119,46 @@ export default function VolunteerEventsList(props: Volunteer) {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {(numPages > 0
-                        ? rows.slice((page - 1) * eventsPerPage, (page - 1) * eventsPerPage + eventsPerPage)
-                        : rows
-                    ).map(row => (
-                        <TableRow key={row.name} className={classes.eventRow}>
-                            <TableCell component="th" scope="row">
-                                <CoreTypography variant="body2">{row.name}</CoreTypography>
-                            </TableCell>
-                            <TableCell align="center">
-                                <CoreTypography variant="body2">
-                                    {row.endDate?.toLocaleDateString("en-us", {
-                                        month: "2-digit",
-                                        day: "2-digit",
-                                        year: "numeric",
-                                    })}
-                                </CoreTypography>
-                            </TableCell>
-                            <TableCell align="center">
-                                <CoreTypography variant="body2">{row.hours}</CoreTypography>
+                    {rows.length > 0 &&
+                        (numPages > 0
+                            ? rows.slice((page - 1) * eventsPerPage, (page - 1) * eventsPerPage + eventsPerPage)
+                            : rows
+                        ).map(row => (
+                            <TableRow key={row.name} className={classes.eventRow}>
+                                <TableCell component="th" scope="row">
+                                    <CoreTypography variant="body2">{row.name}</CoreTypography>
+                                </TableCell>
+                                <TableCell align="center">
+                                    <CoreTypography variant="body2">
+                                        {row.endDate?.toLocaleDateString("en-us", {
+                                            month: "2-digit",
+                                            day: "2-digit",
+                                            year: "numeric",
+                                        })}
+                                    </CoreTypography>
+                                </TableCell>
+                                <TableCell align="center">
+                                    <CoreTypography variant="body2">{row.hours}</CoreTypography>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    {page == numPages && emptyRows > 0 && (
+                        <TableRow style={{ height: 58 * emptyRows }}>
+                            <TableCell colSpan={3} style={{ border: "none" }} />
+                        </TableRow>
+                    )}
+                    {numPages === 0 && (
+                        <TableRow style={{ height: 58 * emptyRows }}>
+                            <TableCell
+                                colSpan={3}
+                                style={{
+                                    border: "none",
+                                }}
+                            >
+                                <CoreTypography variant="body1">No Attended Events</CoreTypography>
                             </TableCell>
                         </TableRow>
-                    ))}
+                    )}
                 </TableBody>
             </Table>
             <div className={classes.tableFooter}>

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -153,7 +153,7 @@ const useStyles = makeStyles((theme: Theme) =>
             },
         },
         nameCard: {
-            border: `2px solid ${theme.palette.primary.light}`,
+            border: `1px solid ${theme.palette.primary.light}`,
             [theme.breakpoints.between(0, "sm")]: {
                 width: "90%",
             },
@@ -186,7 +186,7 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         rightCards: {
             marginLeft: "40px",
-            border: `2px solid ${theme.palette.primary.light}`,
+            border: `1px solid ${theme.palette.primary.light}`,
             [theme.breakpoints.between(0, "sm")]: {
                 marginLeft: "0px",
             },
@@ -200,7 +200,7 @@ const useStyles = makeStyles((theme: Theme) =>
             textAlign: "center",
         },
         nameHeader: {
-            border: `2px solid ${theme.palette.primary.light}`,
+            border: `1px solid ${theme.palette.primary.light}`,
             marginTop: "50px",
             marginBottom: "30px",
             width: "100%",

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import VolunteerEventsList from "../../components/VolunteerEventsList";
-import Header from "src/components/Header";
-import Footer from "src/components/Footer";
 import { getVolunteer } from "server/actions/Volunteer";
 import { Volunteer } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";
 import Error from "next/error";
 import constants from "utils/constants";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import { Paper } from "@material-ui/core";
+import CoreTypography from "src/components/core/typography";
+import { NONAME } from "dns";
 
 interface Props {
     vol: Volunteer;
@@ -22,6 +23,22 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
     return (
         <>
             <div className={classes.container}>
+                <div className={classes.volInfoContainer}>
+                    <Paper className={classes.nameCard} elevation={3}>
+                        <CoreTypography variant="h1">Name</CoreTypography>
+                    </Paper>
+                    <div className={classes.volInfoRight}>
+                        <Paper className={classes.rightCards} elevation={3}>
+                            <CoreTypography variant="h1">Name</CoreTypography>
+                        </Paper>
+                        <Paper className={classes.rightCards} elevation={3}>
+                            <CoreTypography variant="h1">Hours</CoreTypography>
+                        </Paper>
+                    </div>
+                </div>
+                <Paper className={classes.nameHeader}>
+                    <CoreTypography variant="h1">Name Event Header</CoreTypography>
+                </Paper>
                 <VolunteerEventsList {...vol} />
             </div>
         </>
@@ -62,7 +79,57 @@ export async function getStaticPaths() {
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         container: {
-            margin: "50px",
+            margin: "45px",
+        },
+        volInfoContainer: {
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            [theme.breakpoints.between(0, "sm")]: {
+                flexDirection: "column",
+                width: "100%",
+            },
+        },
+        volInfoRight: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            [theme.breakpoints.between(0, "sm")]: {
+                marginTop: "20px",
+                width: "100%",
+            },
+        },
+        nameCard: {
+            [theme.breakpoints.between(0, "sm")]: {
+                width: "100%",
+            },
+            "&>*": {
+                margin: theme.spacing(1),
+                width: theme.spacing(70),
+                height: theme.spacing(30),
+            },
+        },
+        rightCards: {
+            marginLeft: "20px",
+            [theme.breakpoints.between(0, "sm")]: {
+                marginLeft: "0px",
+            },
+            "&>*": {
+                margin: theme.spacing(1),
+                width: theme.spacing(30),
+                height: theme.spacing(30),
+            },
+        },
+        nameHeader: {
+            border: `1px solid ${theme.palette.primary.light}`,
+            marginTop: "20px",
+            marginBottom: "20px",
+            "&>*": {
+                width: "100%",
+                margin: theme.spacing(1),
+                height: theme.spacing(8),
+            },
         },
     })
 );

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -29,11 +29,9 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
     }
     return (
         <>
-            <Header />
             <div className={classes.container}>
                 <VolunteerEventsList {...vol} />
             </div>
-            <Footer />
         </>
     );
 };

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -58,7 +58,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                         <Paper className={classes.rightCards} elevation={2}>
                             <div className={classes.rightCardsContent}>
                                 <CoreTypography variant="body1" style={{ fontSize: "130px" }}>
-                                    {/*vol.totalHours*/}6
+                                    {vol.totalEvents == undefined ? 0 : vol.totalEvents}
                                 </CoreTypography>
                                 <CoreTypography variant="body1">Events Attended</CoreTypography>
                             </div>
@@ -66,8 +66,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                         <Paper className={classes.rightCards} elevation={2}>
                             <div className={classes.rightCardsContent}>
                                 <CoreTypography variant="body1" style={{ fontSize: "130px" }}>
-                                    {/*vol.totalHours*/}
-                                    24
+                                    {vol.totalHours == undefined ? 0 : vol.totalHours}
                                 </CoreTypography>
                                 <CoreTypography variant="body1">Total Hours</CoreTypography>
                             </div>

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -8,7 +8,11 @@ import constants from "utils/constants";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import { Paper } from "@material-ui/core";
 import CoreTypography from "src/components/core/typography";
-import { NONAME } from "dns";
+import EmailIcon from "@material-ui/icons/Email";
+import PhoneIcon from "@material-ui/icons/Phone";
+import DeleteIcon from "@material-ui/icons/Delete";
+import EditIcon from "@material-ui/icons/Edit";
+import colors from "src/components/core/colors";
 
 interface Props {
     vol: Volunteer;
@@ -20,24 +24,68 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
     if (!vol) {
         return <Error statusCode={404} />;
     }
+
+    const firstName = vol.name.split(" ")[0];
+
     return (
         <>
             <div className={classes.container}>
                 <div className={classes.volInfoContainer}>
-                    <Paper className={classes.nameCard} elevation={3}>
-                        <CoreTypography variant="h1">Name</CoreTypography>
+                    <Paper className={classes.nameCard} elevation={2}>
+                        <div className={classes.nameCardContent}>
+                            <CoreTypography variant="body1" style={{ fontSize: "60px" }}>
+                                <div className={classes.nameCardTopRow}>
+                                    {vol.name}
+                                    <div>
+                                        <EditIcon style={{ verticalAlign: "top", marginRight: "5px" }} />
+                                        <DeleteIcon style={{ verticalAlign: "top", marginRight: "5px" }} />
+                                    </div>
+                                </div>
+                            </CoreTypography>
+                            <div>
+                                <CoreTypography variant="body1">
+                                    <EmailIcon fontSize="large" style={{ verticalAlign: "middle" }} />
+                                    &nbsp;&nbsp;{vol.email}
+                                </CoreTypography>
+                                <CoreTypography variant="body1">
+                                    <PhoneIcon fontSize="large" style={{ verticalAlign: "middle" }} />
+                                    &nbsp;&nbsp;{vol.phone}
+                                </CoreTypography>
+                            </div>
+                        </div>
                     </Paper>
                     <div className={classes.volInfoRight}>
-                        <Paper className={classes.rightCards} elevation={3}>
-                            <CoreTypography variant="h1">Name</CoreTypography>
+                        <Paper className={classes.rightCards} elevation={2}>
+                            <div className={classes.rightCardsContent}>
+                                <CoreTypography variant="body1" style={{ fontSize: "130px" }}>
+                                    {/*vol.totalHours*/}6
+                                </CoreTypography>
+                                <CoreTypography variant="body1">Events Attended</CoreTypography>
+                            </div>
                         </Paper>
-                        <Paper className={classes.rightCards} elevation={3}>
-                            <CoreTypography variant="h1">Hours</CoreTypography>
+                        <Paper className={classes.rightCards} elevation={2}>
+                            <div className={classes.rightCardsContent}>
+                                <CoreTypography variant="body1" style={{ fontSize: "130px" }}>
+                                    {/*vol.totalHours*/}
+                                    24
+                                </CoreTypography>
+                                <CoreTypography variant="body1">Total Hours</CoreTypography>
+                            </div>
                         </Paper>
                     </div>
                 </div>
-                <Paper className={classes.nameHeader}>
-                    <CoreTypography variant="h1">Name Event Header</CoreTypography>
+                <Paper className={classes.nameHeader} elevation={0}>
+                    <div className={classes.nameHeaderContent}>
+                        <CoreTypography variant="body1" style={{ fontSize: "35px" }}>
+                            {firstName}&apos;s Events
+                        </CoreTypography>
+                        <button className={classes.hoursVerificationButton}>
+                            <CoreTypography variant="body2">
+                                <EmailIcon fontSize="large" style={{ verticalAlign: "middle" }} />
+                                &nbsp;&nbsp;Total Hours Verification
+                            </CoreTypography>
+                        </button>
+                    </div>
                 </Paper>
                 <VolunteerEventsList {...vol} />
             </div>
@@ -79,13 +127,18 @@ export async function getStaticPaths() {
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         container: {
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
             margin: "45px",
         },
         volInfoContainer: {
             display: "flex",
             flexDirection: "row",
             alignItems: "center",
+            marginTop: "40px",
             justifyContent: "space-between",
+            width: "100%",
             [theme.breakpoints.between(0, "sm")]: {
                 flexDirection: "column",
                 width: "100%",
@@ -97,38 +150,85 @@ const useStyles = makeStyles((theme: Theme) =>
             justifyContent: "space-between",
             [theme.breakpoints.between(0, "sm")]: {
                 marginTop: "20px",
-                width: "100%",
+                width: "90%",
             },
         },
         nameCard: {
+            border: `2px solid ${theme.palette.primary.light}`,
             [theme.breakpoints.between(0, "sm")]: {
-                width: "100%",
+                width: "90%",
             },
             "&>*": {
                 margin: theme.spacing(1),
-                width: theme.spacing(70),
+                width: theme.spacing(65),
                 height: theme.spacing(30),
             },
         },
+        nameCardContent: {
+            paddingTop: "10px",
+            paddingLeft: "40px",
+            paddingBottom: "20px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "left",
+            justifyContent: "space-between",
+        },
+        nameCardTopRow: {
+            width: "100%",
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+            [theme.breakpoints.between(0, "sm")]: {
+                width: "90%",
+            },
+        },
+        nameCardIcons: {
+            textAlign: "right",
+        },
         rightCards: {
-            marginLeft: "20px",
+            marginLeft: "40px",
+            border: `2px solid ${theme.palette.primary.light}`,
             [theme.breakpoints.between(0, "sm")]: {
                 marginLeft: "0px",
             },
             "&>*": {
                 margin: theme.spacing(1),
-                width: theme.spacing(30),
+                width: theme.spacing(27),
                 height: theme.spacing(30),
             },
         },
+        rightCardsContent: {
+            textAlign: "center",
+        },
         nameHeader: {
-            border: `1px solid ${theme.palette.primary.light}`,
-            marginTop: "20px",
-            marginBottom: "20px",
+            border: `2px solid ${theme.palette.primary.light}`,
+            marginTop: "50px",
+            marginBottom: "30px",
+            width: "100%",
             "&>*": {
                 width: "100%",
                 margin: theme.spacing(1),
-                height: theme.spacing(8),
+                height: theme.spacing(7),
+            },
+            [theme.breakpoints.between(0, "sm")]: {
+                width: "90%",
+            },
+        },
+        nameHeaderContent: {
+            paddingLeft: "5px",
+            paddingRight: "20px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+        },
+        hoursVerificationButton: {
+            color: colors.white,
+            backgroundColor: colors.pink,
+            border: "none",
+            padding: "0 8px",
+            borderRadius: "10px",
+            [theme.breakpoints.between(0, "sm")]: {
+                padding: "0 4px",
             },
         },
     })

--- a/src/pages/volunteers/[volId].tsx
+++ b/src/pages/volunteers/[volId].tsx
@@ -13,14 +13,6 @@ interface Props {
     vol: Volunteer;
 }
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        container: {
-            margin: "50px",
-        },
-    })
-);
-
 const VolunteerPage: NextPage<Props> = ({ vol }) => {
     const classes = useStyles();
 
@@ -66,5 +58,13 @@ export async function getStaticPaths() {
 
     return { paths, fallback: true };
 }
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        container: {
+            margin: "50px",
+        },
+    })
+);
 
 export default VolunteerPage;


### PR DESCRIPTION
This PR implements the styling for a volunteer's profile page. I used material-ui's Paper object to create the containers and added responsiveness using the material defined page-width breakpoints. I also updated the events list/table to fill empty space when fewer than 5 events are in current page. Screenshots are below. 

<img width="1280" alt="Screen Shot 2021-03-18 at 2 54 26 PM" src="https://user-images.githubusercontent.com/58822572/111681692-edbb1780-87f9-11eb-9ad0-7fa59e42a4f9.png">

<img width="1280" alt="Screen Shot 2021-03-18 at 2 54 33 PM" src="https://user-images.githubusercontent.com/58822572/111681706-f1e73500-87f9-11eb-9040-3b74aa7567ff.png">

<img width="1280" alt="Screen Shot 2021-03-18 at 2 42 10 PM" src="https://user-images.githubusercontent.com/58822572/111681738-fb709d00-87f9-11eb-9190-4dcab6464bcb.png">

<img width="1280" alt="Screen Shot 2021-03-18 at 2 42 19 PM" src="https://user-images.githubusercontent.com/58822572/111681767-0297ab00-87fa-11eb-9319-73408e7fbe58.png">



