### PR TITLE
Get all vols backend

### DIFF
--- a/src/pages/admin/volunteers/[volId].tsx
+++ b/src/pages/admin/volunteers/[volId].tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import VolunteerEventsList from "../../components/VolunteerEventsList";
+import VolunteerEventsList from "../../../components/VolunteerEventsList";
 import { getVolunteer } from "server/actions/Volunteer";
 import { Volunteer } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";

--- a/src/pages/api/volunteers/index.ts
+++ b/src/pages/api/volunteers/index.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import errors from "utils/errors";
 import formidable from "formidable";
 import { Volunteer, APIError } from "utils/types";
-import { addVolunteer } from "server/actions/Volunteer";
+import { addVolunteer, getVolunteers } from "server/actions/Volunteer";
 
 // formidable config
 export const config = {
@@ -17,12 +17,19 @@ export const config = {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (req.method === "GET") {
-            throw new Error("Not implemented yet");
+            const page: number = parseInt(req.query?.page as string);
+            const search = req.query?.search as string;
+            const volunteers: Volunteer[] = await getVolunteers(page, search);
+
+            res.status(200).json({
+                success: true,
+                payload: { volunteers },
+            });
         } else if (req.method === "POST") {
             const form = new formidable.IncomingForm();
             form.parse(req, async (err: string, fields: formidable.Fields, files: formidable.Files) => {
                 const vol: Volunteer = (fields as unknown) as Volunteer;
-                console.log("volunteerInfo: ", vol);
+
                 await addVolunteer(vol);
                 res.status(200).json({
                     success: true,

--- a/tst/server/Volunteer.test.ts
+++ b/tst/server/Volunteer.test.ts
@@ -1,15 +1,14 @@
 import {
     addVolunteer,
     getVolunteer,
+    getVolunteers,
     markVolunteerNotPresent,
     markVolunteerPresent,
     registerVolunteerToEvent,
 } from "server/actions/Volunteer";
 import VolunteerSchema from "server/models/Volunteer";
-import { Query } from "mongoose";
 import EventSchema from "server/models/Event";
 import { Volunteer, Event } from "utils/types";
-import { Search } from "@material-ui/icons";
 
 jest.mock("server");
 


### PR DESCRIPTION
This PR includes the backend for getting all Volunteers in the system. I set up the API endpoint which takes a page number and an optional search query as GET query parameters. Then MongoDB handles the pagination by sorting, skipping, then limiting the final results. 

I know Alanna wanted to sort by a volunteer's last name, but that's something we can change later on. I kept the name as first+last name because that allows her to search for both (and not just last name).