### PR TITLE
Andrewrutter/kkb 52 mark volunteer present

### DIFF
--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -70,3 +70,25 @@ export const registerVolunteerToEvent = async function (vol: Volunteer, eventId:
     const eventPromise = EventSchema.updateOne({ _id: eventId }, event);
     await Promise.all([volPromise, eventPromise]);
 };
+
+/**
+ * Marks a volunteer present at an event. Also adds the event to a volunteer's attended events list.
+ * @param vol The volunteer id of the volunteer to mark present
+ * @param eventId the event id the volunteer attended
+ */
+export const markVolunteerPresent = async function (volId: string, eventId: string) {
+    await mongoDB();
+    if (!volId || !eventId) {
+        throw new APIError(400, "Invalid input. Need both volunteer and event information.");
+    }
+
+    const event = await EventSchema.findById(eventId);
+    if (!event) {
+        throw new APIError(404, "Event does not exist.");
+    }
+
+    const volunteer = await VolunteerSchema.findById(volId);
+    if (!volunteer) {
+        throw new APIError(404, "Volunteer does not exist.");
+    }
+};

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -91,16 +91,18 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
         throw new APIError(404, "Volunteer does not exist.");
     }
 
-    const volPromise = await VolunteerSchema.findByIdAndUpdate(volId, {
+    const volPromise = VolunteerSchema.findByIdAndUpdate(volId, {
         $push: { attendedEvents: eventId },
         $pull: { registeredEvents: eventId },
         $inc: { totalHours: event.hours!, totalEvents: 1 },
     });
 
-    const eventPromise = await EventSchema.findByIdAndUpdate(eventId, {
+    const eventPromise = EventSchema.findByIdAndUpdate(eventId, {
         $push: { attendedVolunteers: volId },
         $pull: { registeredVolunteers: volId },
     });
+
+    await Promise.all([volPromise, eventPromise]);
 };
 
 /**
@@ -124,14 +126,16 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
         throw new APIError(404, "Volunteer does not exist.");
     }
 
-    const volPromise = await VolunteerSchema.findByIdAndUpdate(volId, {
+    const volPromise = VolunteerSchema.findByIdAndUpdate(volId, {
         $push: { registeredEvents: eventId },
         $pull: { attendedEvents: eventId },
         $inc: { totalHours: -1 * event.hours!, totalEvents: -1 },
     });
 
-    const eventPromise = await EventSchema.findByIdAndUpdate(eventId, {
+    const eventPromise = EventSchema.findByIdAndUpdate(eventId, {
         $push: { registeredVolunteers: volId },
         $pull: { attendedVolunteers: volId },
     });
+
+    await Promise.all([volPromise, eventPromise]);
 };

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -91,11 +91,17 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
         throw new APIError(404, "Volunteer does not exist.");
     }
 
-    if (volunteer.registeredEvents?.indexOf(event?._id) === -1) {
+    if (
+        volunteer.registeredEvents?.indexOf(event?._id) === -1 ||
+        event.registeredVolunteers?.indexOf(volunteer?._id) === -1
+    ) {
         throw new APIError(500, "This volunteer is not signed up for this event.");
     }
 
-    if (volunteer?.attendedEvents?.indexOf(event?._id) !== -1) {
+    if (
+        volunteer?.attendedEvents?.indexOf(event?._id) !== -1 ||
+        event?.attendedVolunteers?.indexOf(volunteer?._id) !== -1
+    ) {
         throw new APIError(500, "The volunteer has already been checked in to this event.");
     }
 
@@ -137,6 +143,13 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
     if (
         volunteer.attendedEvents?.indexOf(event?._id) === -1 ||
         volunteer?.registeredEvents?.indexOf(event?._id) !== -1
+    ) {
+        throw new APIError(500, "This volunteer is not checked in to this event.");
+    }
+
+    if (
+        event.attendedVolunteers?.indexOf(volunteer?._id) === -1 ||
+        event?.registeredVolunteers?.indexOf(volunteer?._id) !== -1
     ) {
         throw new APIError(500, "This volunteer is not checked in to this event.");
     }

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -108,7 +108,7 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
  * @param vol The volunteer id of the volunteer to un-mark present
  * @param eventId the event id the volunteer is registered for
  */
-export const unMarkVolunteerPresent = async function (volId: string, eventId: string) {
+export const markVolunteerNotPresent = async function (volId: string, eventId: string) {
     await mongoDB();
     if (!volId || !eventId) {
         throw new APIError(400, "Invalid input. Need both volunteer and event information.");

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -91,6 +91,14 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
         throw new APIError(404, "Volunteer does not exist.");
     }
 
+    if (volunteer.registeredEvents?.indexOf(event?._id) === -1) {
+        throw new APIError(500, "This volunteer is not signed up for this event.");
+    }
+
+    if (volunteer?.attendedEvents?.indexOf(event?._id) !== -1) {
+        throw new APIError(500, "The volunteer has already been checked in to this event.");
+    }
+
     const volPromise = VolunteerSchema.findByIdAndUpdate(volId, {
         $push: { attendedEvents: eventId },
         $pull: { registeredEvents: eventId },
@@ -124,6 +132,13 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
     const volunteer = await VolunteerSchema.findById(volId);
     if (!volunteer) {
         throw new APIError(404, "Volunteer does not exist.");
+    }
+
+    if (
+        volunteer.attendedEvents?.indexOf(event?._id) === -1 ||
+        volunteer?.registeredEvents?.indexOf(event?._id) !== -1
+    ) {
+        throw new APIError(500, "This volunteer is not checked in to this event.");
     }
 
     const volPromise = VolunteerSchema.findByIdAndUpdate(volId, {

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -102,3 +102,36 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
         $pull: { registeredVolunteers: volId },
     });
 };
+
+/**
+ * Un-marks volunteer as present at an event. Does the same to the volunteer's attended events list.
+ * @param vol The volunteer id of the volunteer to un-mark present
+ * @param eventId the event id the volunteer is registered for
+ */
+export const unMarkVolunteerPresent = async function (volId: string, eventId: string) {
+    await mongoDB();
+    if (!volId || !eventId) {
+        throw new APIError(400, "Invalid input. Need both volunteer and event information.");
+    }
+
+    const event = await EventSchema.findById(eventId);
+    if (!event) {
+        throw new APIError(404, "Event does not exist.");
+    }
+
+    const volunteer = await VolunteerSchema.findById(volId);
+    if (!volunteer) {
+        throw new APIError(404, "Volunteer does not exist.");
+    }
+
+    const volPromise = await VolunteerSchema.findByIdAndUpdate(volId, {
+        $push: { registeredEvents: eventId },
+        $pull: { attendedEvents: eventId },
+        $inc: { totalHours: -1 * event.hours!, totalEvents: -1 },
+    });
+
+    const eventPromise = await EventSchema.findByIdAndUpdate(eventId, {
+        $push: { registeredVolunteers: volId },
+        $pull: { attendedVolunteers: volId },
+    });
+};

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -72,7 +72,7 @@ export const registerVolunteerToEvent = async function (vol: Volunteer, eventId:
 
 /**
  * Marks a volunteer present at an event. Also adds the event to a volunteer's attended events list.
- * @param vol The volunteer id of the volunteer to mark present
+ * @param volId The volunteer id of the volunteer to mark present
  * @param eventId the event id the volunteer attended
  */
 export const markVolunteerPresent = async function (volId: string, eventId: string) {
@@ -92,17 +92,17 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
     }
 
     if (
-        volunteer.registeredEvents?.indexOf(event?._id) === -1 ||
-        event.registeredVolunteers?.indexOf(volunteer?._id) === -1
+        volunteer.attendedEvents?.indexOf(event?._id) !== -1 ||
+        event.attendedVolunteers?.indexOf(volunteer?._id) !== -1
     ) {
-        throw new APIError(500, "This volunteer is not signed up for this event.");
+        throw new APIError(500, "The volunteer has already been checked in to this event.");
     }
 
     if (
-        volunteer?.attendedEvents?.indexOf(event?._id) !== -1 ||
-        event?.attendedVolunteers?.indexOf(volunteer?._id) !== -1
+        volunteer.registeredEvents?.indexOf(event?._id) === -1 ||
+        event.registeredVolunteers?.indexOf(volunteer?._id) === -1
     ) {
-        throw new APIError(500, "The volunteer has already been checked in to this event.");
+        throw new APIError(500, "This volunteer is not registered for this event.");
     }
 
     const volPromise = VolunteerSchema.findByIdAndUpdate(volId, {
@@ -121,7 +121,7 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
 
 /**
  * Un-marks volunteer as present at an event. Does the same to the volunteer's attended events list.
- * @param vol The volunteer id of the volunteer to un-mark present
+ * @param volId The volunteer id of the volunteer to un-mark present
  * @param eventId the event id the volunteer is registered for
  */
 export const markVolunteerNotPresent = async function (volId: string, eventId: string) {

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -102,7 +102,7 @@ export const markVolunteerPresent = async function (volId: string, eventId: stri
         volunteer.registeredEvents?.indexOf(event?._id) === -1 ||
         event.registeredVolunteers?.indexOf(volunteer?._id) === -1
     ) {
-        throw new APIError(500, "This volunteer is not registered for this event.");
+        throw new APIError(500, "The volunteer is not registered for this event.");
     }
 
     const volPromise = VolunteerSchema.findByIdAndUpdate(volId, {
@@ -144,14 +144,14 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
         volunteer.attendedEvents?.indexOf(event?._id) === -1 ||
         volunteer?.registeredEvents?.indexOf(event?._id) !== -1
     ) {
-        throw new APIError(500, "This volunteer is not checked in to this event.");
+        throw new APIError(500, "The volunteer is not checked in to this event.");
     }
 
     if (
         event.attendedVolunteers?.indexOf(volunteer?._id) === -1 ||
         event?.registeredVolunteers?.indexOf(volunteer?._id) !== -1
     ) {
-        throw new APIError(500, "This volunteer is not checked in to this event.");
+        throw new APIError(500, "The volunteer is not checked in to this event.");
     }
 
     const volPromise = VolunteerSchema.findByIdAndUpdate(volId, {

--- a/src/pages/api/events/[eventId]/notPresent/[volid].ts
+++ b/src/pages/api/events/[eventId]/notPresent/[volid].ts
@@ -1,0 +1,37 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { unMarkVolunteerPresent } from "server/actions/Volunteer";
+import errors from "utils/errors";
+import { APIError } from "utils/types";
+
+// GET /api/events/[eventId]/notPresent/[volId] will unmark volunteer volId as present for event eventId
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        if (!req || !req.query || !req.query.eventId || !req.query.volId) {
+            throw new Error("Need an event id and a volunteer id for this route.");
+        }
+
+        if (req.method == "GET") {
+            const eventId = req.query.eventId as string;
+            const volId = req.query.volId as string;
+
+            await unMarkVolunteerPresent(volId, eventId);
+            res.status(200).json({
+                success: true,
+                payload: {},
+            });
+        }
+    } catch (error) {
+        if (error instanceof APIError) {
+            res.status(error.statusCode).json({
+                success: false,
+                message: error.message,
+            });
+        } else {
+            console.error(error instanceof Error && error);
+            res.status(500).json({
+                success: false,
+                message: (error instanceof Error && error.message) || errors.GENERIC_ERROR,
+            });
+        }
+    }
+}

--- a/src/pages/api/events/[eventId]/notPresent/[volid].ts
+++ b/src/pages/api/events/[eventId]/notPresent/[volid].ts
@@ -3,14 +3,14 @@ import { markVolunteerNotPresent } from "server/actions/Volunteer";
 import errors from "utils/errors";
 import { APIError } from "utils/types";
 
-// GET /api/events/[eventId]/notPresent/[volId] will unmark volunteer volId as present for event eventId
+// POST /api/events/[eventId]/notPresent/[volId] will unmark volunteer volId as present for event eventId
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (!req || !req.query || !req.query.eventId || !req.query.volId) {
             throw new Error("Need an event id and a volunteer id for this route.");
         }
 
-        if (req.method == "GET") {
+        if (req.method == "POST") {
             const eventId = req.query.eventId as string;
             const volId = req.query.volId as string;
 

--- a/src/pages/api/events/[eventId]/notPresent/[volid].ts
+++ b/src/pages/api/events/[eventId]/notPresent/[volid].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { unMarkVolunteerPresent } from "server/actions/Volunteer";
+import { markVolunteerNotPresent } from "server/actions/Volunteer";
 import errors from "utils/errors";
 import { APIError } from "utils/types";
 
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             const eventId = req.query.eventId as string;
             const volId = req.query.volId as string;
 
-            await unMarkVolunteerPresent(volId, eventId);
+            await markVolunteerNotPresent(volId, eventId);
             res.status(200).json({
                 success: true,
                 payload: {},

--- a/src/pages/api/events/[eventId]/present/[volId].ts
+++ b/src/pages/api/events/[eventId]/present/[volId].ts
@@ -1,2 +1,37 @@
-export {};
+import { NextApiRequest, NextApiResponse } from "next";
+import { markVolunteerPresent } from "server/actions/Volunteer";
+import errors from "utils/errors";
+import { APIError } from "utils/types";
+
 // GET /api/events/[eventId]/present/[volId] will mark volunteer volId as present for event eventId
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        if (!req || !req.query || !req.query.eventId || !req.query.volId) {
+            throw new Error("Need an event id a volunteer id for this route.");
+        }
+
+        if (req.method == "GET") {
+            const eventId = req.query.eventId as string;
+            const volId = req.query.volId as string;
+
+            await markVolunteerPresent(volId, eventId);
+            res.status(200).json({
+                success: true,
+                payload: {},
+            });
+        }
+    } catch (error) {
+        if (error instanceof APIError) {
+            res.status(error.statusCode).json({
+                success: false,
+                message: error.message,
+            });
+        } else {
+            console.error(error instanceof Error && error);
+            res.status(500).json({
+                success: false,
+                message: (error instanceof Error && error.message) || errors.GENERIC_ERROR,
+            });
+        }
+    }
+}

--- a/src/pages/api/events/[eventId]/present/[volId].ts
+++ b/src/pages/api/events/[eventId]/present/[volId].ts
@@ -7,7 +7,7 @@ import { APIError } from "utils/types";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (!req || !req.query || !req.query.eventId || !req.query.volId) {
-            throw new Error("Need an event id a volunteer id for this route.");
+            throw new Error("Need an event id and a volunteer id for this route.");
         }
 
         if (req.method == "GET") {

--- a/src/pages/api/events/[eventId]/present/[volId].ts
+++ b/src/pages/api/events/[eventId]/present/[volId].ts
@@ -3,14 +3,14 @@ import { markVolunteerPresent } from "server/actions/Volunteer";
 import errors from "utils/errors";
 import { APIError } from "utils/types";
 
-// GET /api/events/[eventId]/present/[volId] will mark volunteer volId as present for event eventId
+// POST /api/events/[eventId]/present/[volId] will mark volunteer volId as present for event eventId
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (!req || !req.query || !req.query.eventId || !req.query.volId) {
             throw new Error("Need an event id and a volunteer id for this route.");
         }
 
-        if (req.method == "GET") {
+        if (req.method == "POST") {
             const eventId = req.query.eventId as string;
             const volId = req.query.volId as string;
 

--- a/tst/server/Volunteer.test.ts
+++ b/tst/server/Volunteer.test.ts
@@ -120,7 +120,7 @@ describe("registerVolunteerToEvent() tests", () => {
             email: "jsmith@gmail.com",
             phone: "(931) 931-9319",
             totalEvents: 2,
-            totalHours: 8,
+            totalHours: 5,
             registeredEvents: ["604d6730ca1c1d7fcd4fbdc2", "604d6730ca1c1d7fcd4fbdc9"],
             attendedEvents: ["604d6730ca1c1d7fcd4fbdc3", "604d6730ca1c1d7fcd4fbdc4"],
         };
@@ -249,8 +249,6 @@ describe("registerVolunteerToEvent() tests", () => {
 
 describe("markVolunteerPresent() tests", () => {
     test("successfully checked in", async () => {
-        const eventId = "604d6730ca1c1d7fcd4fbdc9";
-        const volId = "604d6730ca1c1d7fcd4fbde0";
         const mockEvent: Event = {
             _id: "604d6730ca1c1d7fcd4fbdc9",
             name: "February Spruce Up",
@@ -278,34 +276,116 @@ describe("markVolunteerPresent() tests", () => {
             phone: "(931) 931-9319",
             totalEvents: 2,
             totalHours: 5,
-            registeredEvents: ["604d6730ca1c1d7fcd4fbdc9"],
+            registeredEvents: ["604d6730ca1c1d7fcd4fbdc9", "604d6730ca1c1d7fcd4fbbb1"],
             attendedEvents: [],
         };
-
-        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent._id);
-        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer._id);
-
-        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent._id);
-        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer._id);
-
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer);
+        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
         await markVolunteerPresent(mockVolunteer._id!, mockEvent._id!);
         expect(EventSchema.findById).lastCalledWith(mockEvent._id);
         expect(EventSchema.findById).toHaveBeenCalledTimes(1);
         expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
         expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
-
         expect(EventSchema.findByIdAndUpdate).lastCalledWith(mockEvent._id, {
             $pull: { registeredVolunteers: mockVolunteer._id },
             $push: { attendedVolunteers: mockVolunteer._id },
         });
         expect(EventSchema.findByIdAndUpdate).toHaveBeenCalledTimes(1);
-
-        // WHY DOESN'T THIS PASS?
         expect(VolunteerSchema.findByIdAndUpdate).lastCalledWith(mockVolunteer._id, {
             $pull: { registeredEvents: mockEvent._id },
             $push: { attendedEvents: mockEvent._id },
             $inc: { totalEvents: 1, totalHours: mockEvent.hours },
         });
         expect(VolunteerSchema.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test("volunteer not registered", async () => {
+        const mockEvent: Event = {
+            _id: "604d6730ca1c1d7fcd4fbdc9",
+            name: "February Spruce Up",
+            description: "We are sprucing in February. Come spruce with us :)",
+            caption: "It's spruce season",
+            maxVolunteers: 10,
+            volunteerCount: 4,
+            location: "1234 Neyland Dr\nKnoxville, TN 37916",
+            startDate: new Date(Date.now()),
+            endDate: new Date(Date.now()),
+            startRegistration: new Date(Date.now()),
+            endRegistration: new Date(Date.now()),
+            hours: 3,
+            image: {
+                assetID: "aASDuiHWIDUOHWEff",
+                url: "https://i.imgur.com/MrGY5EL.jpeg",
+            },
+            registeredVolunteers: ["604d6730ca1c1d7fcd4fbdd2", "604d6730ca1c1d7fcd4fbdd3"],
+            attendedVolunteers: [],
+        };
+        const mockVolunteer: Volunteer = {
+            _id: "604d6730ca1c1d7fcd4fbde0",
+            name: "John Smith",
+            email: "jsmith@gmail.com",
+            phone: "(931) 931-9319",
+            totalEvents: 2,
+            totalHours: 5,
+            registeredEvents: ["604d6730ca1c1d7fcd4fbbb1"],
+            attendedEvents: [],
+        };
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer);
+        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
+        await expect(markVolunteerPresent(mockVolunteer._id!, mockEvent._id!)).rejects.toThrowError(
+            "This volunteer is not registered for this event."
+        );
+        expect(EventSchema.findById).lastCalledWith(mockEvent._id);
+        expect(EventSchema.findById).toHaveBeenCalledTimes(1);
+        expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
+        expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
+    });
+
+    test("volunteer already checked in", async () => {
+        const mockEvent: Event = {
+            _id: "604d6730ca1c1d7fcd4fbdc9",
+            name: "February Spruce Up",
+            description: "We are sprucing in February. Come spruce with us :)",
+            caption: "It's spruce season",
+            maxVolunteers: 10,
+            volunteerCount: 4,
+            location: "1234 Neyland Dr\nKnoxville, TN 37916",
+            startDate: new Date(Date.now()),
+            endDate: new Date(Date.now()),
+            startRegistration: new Date(Date.now()),
+            endRegistration: new Date(Date.now()),
+            hours: 3,
+            image: {
+                assetID: "aASDuiHWIDUOHWEff",
+                url: "https://i.imgur.com/MrGY5EL.jpeg",
+            },
+            registeredVolunteers: ["604d6730ca1c1d7fcd4fbdd2", "604d6730ca1c1d7fcd4fbdd3"],
+            attendedVolunteers: ["604d6730ca1c1d7fcd4fbde0"],
+        };
+        const mockVolunteer: Volunteer = {
+            _id: "604d6730ca1c1d7fcd4fbde0",
+            name: "John Smith",
+            email: "jsmith@gmail.com",
+            phone: "(931) 931-9319",
+            totalEvents: 2,
+            totalHours: 5,
+            registeredEvents: ["604d6730ca1c1d7fcd4fbbb1"],
+            attendedEvents: ["604d6730ca1c1d7fcd4fbdc9"],
+        };
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer);
+        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
+        await expect(markVolunteerPresent(mockVolunteer._id!, mockEvent._id!)).rejects.toThrowError(
+            "The volunteer has already been checked in to this event."
+        );
+        expect(EventSchema.findById).lastCalledWith(mockEvent._id);
+        expect(EventSchema.findById).toHaveBeenCalledTimes(1);
+        expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
+        expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
     });
 });

--- a/tst/server/Volunteer.test.ts
+++ b/tst/server/Volunteer.test.ts
@@ -1,4 +1,10 @@
-import { addVolunteer, getVolunteer, markVolunteerPresent, registerVolunteerToEvent } from "server/actions/Volunteer";
+import {
+    addVolunteer,
+    getVolunteer,
+    markVolunteerNotPresent,
+    markVolunteerPresent,
+    registerVolunteerToEvent,
+} from "server/actions/Volunteer";
 import VolunteerSchema from "server/models/Volunteer";
 import EventSchema from "server/models/Event";
 import { Volunteer, Event } from "utils/types";
@@ -337,7 +343,7 @@ describe("markVolunteerPresent() tests", () => {
         EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent);
         VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
         await expect(markVolunteerPresent(mockVolunteer._id!, mockEvent._id!)).rejects.toThrowError(
-            "This volunteer is not registered for this event."
+            "The volunteer is not registered for this event."
         );
         expect(EventSchema.findById).lastCalledWith(mockEvent._id);
         expect(EventSchema.findById).toHaveBeenCalledTimes(1);
@@ -382,6 +388,105 @@ describe("markVolunteerPresent() tests", () => {
         VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
         await expect(markVolunteerPresent(mockVolunteer._id!, mockEvent._id!)).rejects.toThrowError(
             "The volunteer has already been checked in to this event."
+        );
+        expect(EventSchema.findById).lastCalledWith(mockEvent._id);
+        expect(EventSchema.findById).toHaveBeenCalledTimes(1);
+        expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
+        expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("markVolunteerNotPresent() tests", () => {
+    test("successfully un-checked in", async () => {
+        const mockEvent: Event = {
+            _id: "604d6730ca1c1d7fcd4fbdc9",
+            name: "February Spruce Up",
+            description: "We are sprucing in February. Come spruce with us :)",
+            caption: "It's spruce season",
+            maxVolunteers: 10,
+            volunteerCount: 4,
+            location: "1234 Neyland Dr\nKnoxville, TN 37916",
+            startDate: new Date(Date.now()),
+            endDate: new Date(Date.now()),
+            startRegistration: new Date(Date.now()),
+            endRegistration: new Date(Date.now()),
+            hours: 3,
+            image: {
+                assetID: "aASDuiHWIDUOHWEff",
+                url: "https://i.imgur.com/MrGY5EL.jpeg",
+            },
+            registeredVolunteers: ["604d6730ca1c1d7fcd4fbdd2", "604d6730ca1c1d7fcd4fbdd3"],
+            attendedVolunteers: ["604d6730ca1c1d7fcd4fbde0"],
+        };
+        const mockVolunteer: Volunteer = {
+            _id: "604d6730ca1c1d7fcd4fbde0",
+            name: "John Smith",
+            email: "jsmith@gmail.com",
+            phone: "(931) 931-9319",
+            totalEvents: 2,
+            totalHours: 5,
+            registeredEvents: ["604d6730ca1c1d7fcd4fbbb1"],
+            attendedEvents: ["604d6730ca1c1d7fcd4fbdc9"],
+        };
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer);
+        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
+        await markVolunteerNotPresent(mockVolunteer._id!, mockEvent._id!);
+        expect(EventSchema.findById).lastCalledWith(mockEvent._id);
+        expect(EventSchema.findById).toHaveBeenCalledTimes(1);
+        expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
+        expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
+        expect(EventSchema.findByIdAndUpdate).lastCalledWith(mockEvent._id, {
+            $pull: { attendedVolunteers: mockVolunteer._id },
+            $push: { registeredVolunteers: mockVolunteer._id },
+        });
+        expect(EventSchema.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+        expect(VolunteerSchema.findByIdAndUpdate).lastCalledWith(mockVolunteer._id, {
+            $pull: { attendedEvents: mockEvent._id },
+            $push: { registeredEvents: mockEvent._id },
+            $inc: { totalEvents: -1, totalHours: -1 * mockEvent.hours! },
+        });
+        expect(VolunteerSchema.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test("volunteer not checked in", async () => {
+        const mockEvent: Event = {
+            _id: "604d6730ca1c1d7fcd4fbdc9",
+            name: "February Spruce Up",
+            description: "We are sprucing in February. Come spruce with us :)",
+            caption: "It's spruce season",
+            maxVolunteers: 10,
+            volunteerCount: 4,
+            location: "1234 Neyland Dr\nKnoxville, TN 37916",
+            startDate: new Date(Date.now()),
+            endDate: new Date(Date.now()),
+            startRegistration: new Date(Date.now()),
+            endRegistration: new Date(Date.now()),
+            hours: 3,
+            image: {
+                assetID: "aASDuiHWIDUOHWEff",
+                url: "https://i.imgur.com/MrGY5EL.jpeg",
+            },
+            registeredVolunteers: ["604d6730ca1c1d7fcd4fbdd2", "604d6730ca1c1d7fcd4fbdd3", "604d6730ca1c1d7fcd4fbde0"],
+            attendedVolunteers: [],
+        };
+        const mockVolunteer: Volunteer = {
+            _id: "604d6730ca1c1d7fcd4fbde0",
+            name: "John Smith",
+            email: "jsmith@gmail.com",
+            phone: "(931) 931-9319",
+            totalEvents: 2,
+            totalHours: 5,
+            registeredEvents: ["604d6730ca1c1d7fcd4fbbb1", "604d6730ca1c1d7fcd4fbdc9", "604d6730ca1c1d7fcd4fbdc9"],
+            attendedEvents: [],
+        };
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer);
+        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
+        await expect(markVolunteerNotPresent(mockVolunteer._id!, mockEvent._id!)).rejects.toThrowError(
+            "The volunteer is not checked in to this event."
         );
         expect(EventSchema.findById).lastCalledWith(mockEvent._id);
         expect(EventSchema.findById).toHaveBeenCalledTimes(1);

--- a/tst/server/Volunteer.test.ts
+++ b/tst/server/Volunteer.test.ts
@@ -450,7 +450,7 @@ describe("markVolunteerNotPresent() tests", () => {
         expect(VolunteerSchema.findByIdAndUpdate).toHaveBeenCalledTimes(1);
     });
 
-    test("volunteer not checked in", async () => {
+    test("volunteer not checked in event-side", async () => {
         const mockEvent: Event = {
             _id: "604d6730ca1c1d7fcd4fbdc9",
             name: "February Spruce Up",
@@ -470,6 +470,50 @@ describe("markVolunteerNotPresent() tests", () => {
             },
             registeredVolunteers: ["604d6730ca1c1d7fcd4fbdd2", "604d6730ca1c1d7fcd4fbdd3", "604d6730ca1c1d7fcd4fbde0"],
             attendedVolunteers: [],
+        };
+        const mockVolunteer: Volunteer = {
+            _id: "604d6730ca1c1d7fcd4fbde0",
+            name: "John Smith",
+            email: "jsmith@gmail.com",
+            phone: "(931) 931-9319",
+            totalEvents: 2,
+            totalHours: 5,
+            registeredEvents: ["604d6730ca1c1d7fcd4fbbb1"],
+            attendedEvents: ["604d6730ca1c1d7fcd4fbdc9"],
+        };
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer);
+        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent);
+        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer);
+        await expect(markVolunteerNotPresent(mockVolunteer._id!, mockEvent._id!)).rejects.toThrowError(
+            "The volunteer is not checked in to this event."
+        );
+        expect(EventSchema.findById).lastCalledWith(mockEvent._id);
+        expect(EventSchema.findById).toHaveBeenCalledTimes(1);
+        expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
+        expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
+    });
+
+    test("volunteer not checked in volunteer-side", async () => {
+        const mockEvent: Event = {
+            _id: "604d6730ca1c1d7fcd4fbdc9",
+            name: "February Spruce Up",
+            description: "We are sprucing in February. Come spruce with us :)",
+            caption: "It's spruce season",
+            maxVolunteers: 10,
+            volunteerCount: 4,
+            location: "1234 Neyland Dr\nKnoxville, TN 37916",
+            startDate: new Date(Date.now()),
+            endDate: new Date(Date.now()),
+            startRegistration: new Date(Date.now()),
+            endRegistration: new Date(Date.now()),
+            hours: 3,
+            image: {
+                assetID: "aASDuiHWIDUOHWEff",
+                url: "https://i.imgur.com/MrGY5EL.jpeg",
+            },
+            registeredVolunteers: ["604d6730ca1c1d7fcd4fbdd2", "604d6730ca1c1d7fcd4fbdd3"],
+            attendedVolunteers: ["604d6730ca1c1d7fcd4fbde0"],
         };
         const mockVolunteer: Volunteer = {
             _id: "604d6730ca1c1d7fcd4fbde0",

--- a/tst/server/Volunteer.test.ts
+++ b/tst/server/Volunteer.test.ts
@@ -1,4 +1,4 @@
-import { addVolunteer, getVolunteer, registerVolunteerToEvent } from "server/actions/Volunteer";
+import { addVolunteer, getVolunteer, markVolunteerPresent, registerVolunteerToEvent } from "server/actions/Volunteer";
 import VolunteerSchema from "server/models/Volunteer";
 import EventSchema from "server/models/Event";
 import { Volunteer, Event } from "utils/types";
@@ -244,5 +244,68 @@ describe("registerVolunteerToEvent() tests", () => {
         expect(EventSchema.findById).lastCalledWith(eventId);
         expect(EventSchema.findById).toHaveBeenCalledTimes(1);
         expect(VolunteerSchema.findOneAndUpdate).toHaveBeenCalledTimes(0);
+    });
+});
+
+describe("markVolunteerPresent() tests", () => {
+    test("successfully checked in", async () => {
+        const eventId = "604d6730ca1c1d7fcd4fbdc9";
+        const volId = "604d6730ca1c1d7fcd4fbde0";
+        const mockEvent: Event = {
+            _id: "604d6730ca1c1d7fcd4fbdc9",
+            name: "February Spruce Up",
+            description: "We are sprucing in February. Come spruce with us :)",
+            caption: "It's spruce season",
+            maxVolunteers: 10,
+            volunteerCount: 4,
+            location: "1234 Neyland Dr\nKnoxville, TN 37916",
+            startDate: new Date(Date.now()),
+            endDate: new Date(Date.now()),
+            startRegistration: new Date(Date.now()),
+            endRegistration: new Date(Date.now()),
+            hours: 3,
+            image: {
+                assetID: "aASDuiHWIDUOHWEff",
+                url: "https://i.imgur.com/MrGY5EL.jpeg",
+            },
+            registeredVolunteers: ["604d6730ca1c1d7fcd4fbdd2", "604d6730ca1c1d7fcd4fbdd3", "604d6730ca1c1d7fcd4fbde0"],
+            attendedVolunteers: [],
+        };
+        const mockVolunteer: Volunteer = {
+            _id: "604d6730ca1c1d7fcd4fbde0",
+            name: "John Smith",
+            email: "jsmith@gmail.com",
+            phone: "(931) 931-9319",
+            totalEvents: 2,
+            totalHours: 5,
+            registeredEvents: ["604d6730ca1c1d7fcd4fbdc9"],
+            attendedEvents: [],
+        };
+
+        EventSchema.findById = jest.fn().mockResolvedValue(mockEvent._id);
+        VolunteerSchema.findById = jest.fn().mockResolvedValue(mockVolunteer._id);
+
+        EventSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockEvent._id);
+        VolunteerSchema.findByIdAndUpdate = jest.fn().mockResolvedValue(mockVolunteer._id);
+
+        await markVolunteerPresent(mockVolunteer._id!, mockEvent._id!);
+        expect(EventSchema.findById).lastCalledWith(mockEvent._id);
+        expect(EventSchema.findById).toHaveBeenCalledTimes(1);
+        expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
+        expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
+
+        expect(EventSchema.findByIdAndUpdate).lastCalledWith(mockEvent._id, {
+            $pull: { registeredVolunteers: mockVolunteer._id },
+            $push: { attendedVolunteers: mockVolunteer._id },
+        });
+        expect(EventSchema.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+
+        // WHY DOESN'T THIS PASS?
+        expect(VolunteerSchema.findByIdAndUpdate).lastCalledWith(mockVolunteer._id, {
+            $pull: { registeredEvents: mockEvent._id },
+            $push: { attendedEvents: mockEvent._id },
+            $inc: { totalEvents: 1, totalHours: mockEvent.hours },
+        });
+        expect(VolunteerSchema.findByIdAndUpdate).toHaveBeenCalledTimes(1);
     });
 });

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -19,6 +19,7 @@ export default {
         eventVolunteers: (eventId: string) => `/api/events/${eventId}/volunteers`,
         signup: (eventId: string) => `/api/events/${eventId}/signup`,
         markPresent: (eventId: string, volId: string) => `/api/events/${eventId}/present/${volId}`,
+        markNotPresent: (eventId: string, volId: string) => `/api/events/${eventId}/notPresent/${volId}`,
         volunteers: "/api/volunteers",
         volunteer: (volId: string) => `/api/volunteers/${volId}`,
     },


### PR DESCRIPTION
This PR resolves 3 issues:
1. Checking in a volunteer. For the volunteer object, it moves the eventId from `registeredEvents` to `attendedEvents`, and does the same to the event object but with the volunteerId. This is a duplicate of KKB-53 but just has some extra doo-dads like increasing the `totalEvents` and `totalHours` fields for the volunteer.
Performed with `GET /api/events/[eventId]/Present/[volId]`, which triggers the `markVolunteerPresent()` function, which takes volunteer and event IDs as arguments.
2. Un-checking in a volunteer. Exact reverse process as checking in. Moves IDs from the attended field to the registered field for both the volunteer and event objects, and decreases `totalEvents` and `totalHours` fields.
Performed with `GET /api/events/[eventId]/notPresent/[volId]`, which triggers the `markVolunteerNotPresent()` function, which takes volunteer and event IDs as arguments.
3. Resolved issue KKB-54. Small issue, but hours were previously being added on _registration_, and not on check in. 

Also completed/modified tests for all three issues. Tested the first two issues with postman and mongoDB, and it works great!

Let me know if there are any other tests you'd like me to add, or any naming things you'd like me to change for consistency!

(Not sure why there is a merge conflict in `src/components/EventSignUp/index.tsx` but that is what is causing my checks to fail)