### PR TITLE
Get an events volunteers

### DIFF
--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -88,14 +88,15 @@ export const getEventVolunteers = async function (eventId: string, page: number,
 
     // 2. determine what to fill the return array with:
     // if size >= (page+1) * VOLS_PER_PAGE
+    //   skip: page * VOLS_PER_PAGE
     //   all registered
     // else if size > page * VOLS_PER_PAGE
     //   // numberRegistered = VOLS_PER_PAGE * (page+1) - size
-    //   numberAttended = size % VOLS_PER_PAGE
-    //   numberRegistered = VOLS_PER_PAGE - numberAttended
+    //   numberAttendedMixed = size % VOLS_PER_PAGE
+    //   numberRegisteredMixed = VOLS_PER_PAGE - numberAttended
     //   mixed
     // else
-    //   skip: size % VOLS_PER_PAGE (mixed) + pages in for attended * VOLS_PER_PAGE
+    //   skip: numberAttendedMixed + (page * VOLS_PER_PAGE) - (numberAttendedMixed + size)
     //   all attended
 
     // 3. return vols array + registered count

--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -79,7 +79,12 @@ export const deleteEvent = async function (id: string) {
 };
 
 /**
- * @param page
+ * @param eventId The id of the event to get volunteers from.
+ * @param page Since this data is paginated, page is used to return a certain subset of the data.
+ * @param search Optional parameter used to search volunteers by name.
+ * @returns A limited number of volunteers in an array. The return type always includes registered
+ *   vols first (if any are needed for this page), then attended vols. Also specifies the number of
+ *   registered vols in the array (see PaginatedVolunteers type).
  */
 export const getEventVolunteers = async function (eventId: string, page: number, search?: string) {
     await mongoDB();

--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -100,11 +100,9 @@ export const getEventVolunteers = async function (eventId: string, page: number,
         throw new APIError(404, "Event not found.");
     }
     const totalRegistered = model[0]?.numberRegistered;
-    console.log("totalRegistered:", totalRegistered);
 
     // determine what to fill the return array with
     if (totalRegistered >= (page + 1) * VOLS_PER_PAGE) {
-        console.log("all registered vols");
         // return array will contain all registered vols
         const event = await EventSchema.findById(eventId).populate({
             path: "registeredVolunteers",
@@ -119,13 +117,9 @@ export const getEventVolunteers = async function (eventId: string, page: number,
         volunteers = event?.registeredVolunteers as Volunteer[];
         numberRegistered = VOLS_PER_PAGE;
     } else if (totalRegistered > page * VOLS_PER_PAGE) {
-        console.log("mixed vols");
         // mixed w/ registered + attended
         const numberRegisteredMixed = totalRegistered % VOLS_PER_PAGE;
         const numberAttendedMixed = VOLS_PER_PAGE - numberRegisteredMixed;
-        console.log("attended count:", numberAttendedMixed);
-        console.log("registered count:", numberRegisteredMixed);
-
         const event = await EventSchema.findById(eventId)
             .populate({
                 path: "registeredVolunteers",
@@ -149,7 +143,6 @@ export const getEventVolunteers = async function (eventId: string, page: number,
         volunteers = event?.registeredVolunteers?.concat(event?.attendedVolunteers as Volunteer[]) as Volunteer[];
         numberRegistered = numberRegisteredMixed;
     } else {
-        console.log("all attended vols");
         // all attended volunteers
         const numberAttendedMixed = totalRegistered % VOLS_PER_PAGE;
         const event = await EventSchema.findById(eventId).populate({

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,11 @@
 import mongoose from "mongoose";
 import urls from "utils/urls";
 
+// load the models before we start using them or else they wont
+// be defined and we get a MissingSchemaError
+require("./models/Volunteer");
+require("./models/Event");
+
 export default async () => {
     if (mongoose.connections[0].readyState) return;
     const DB_URL: string = urls.dbUrl;

--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -53,27 +53,16 @@ export const EventSchema = new Schema({
         required: false,
     },
     registeredVolunteers: {
-        // type: [{ //denormalize name for search
-        //     volunteer: { type: Schema.Types.ObjectId, ref: "Volunteer" },
-        //     name: String,
-        // }],
         type: [{ type: Schema.Types.ObjectId, ref: "Volunteer" }],
         required: false,
         default: [],
     },
     attendedVolunteers: {
-        // type: [{ //denormalize name for search
-        //     volunteer: { type: Schema.Types.ObjectId, ref: "Volunteer" },
-        //     name: String,
-        // }],
         type: [{ type: Schema.Types.ObjectId, ref: "Volunteer" }],
         required: false,
         default: [],
     },
 });
-
-// middleware to add name on save?
-// middleware to remove name on find?
 
 export interface EventDocument extends Omit<Event, "_id">, Document {}
 

--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -53,16 +53,27 @@ export const EventSchema = new Schema({
         required: false,
     },
     registeredVolunteers: {
+        // type: [{ //denormalize name for search
+        //     volunteer: { type: Schema.Types.ObjectId, ref: "Volunteer" },
+        //     name: String,
+        // }],
         type: [{ type: Schema.Types.ObjectId, ref: "Volunteer" }],
         required: false,
         default: [],
     },
     attendedVolunteers: {
+        // type: [{ //denormalize name for search
+        //     volunteer: { type: Schema.Types.ObjectId, ref: "Volunteer" },
+        //     name: String,
+        // }],
         type: [{ type: Schema.Types.ObjectId, ref: "Volunteer" }],
         required: false,
         default: [],
     },
 });
+
+// middleware to add name on save?
+// middleware to remove name on find?
 
 export interface EventDocument extends Omit<Event, "_id">, Document {}
 

--- a/src/pages/api/events/[eventId]/volunteers.ts
+++ b/src/pages/api/events/[eventId]/volunteers.ts
@@ -3,7 +3,9 @@ import { getEventVolunteers } from "server/actions/Event";
 import errors from "utils/errors";
 import { Event, APIError, PaginatedVolunteers } from "utils/types";
 
-// @route   GET /api/events/[eventId]/volunteers - Returns a paginated list of volunteers for event eventId. - Private
+// @route   GET /api/events/[eventId]/volunteers - Returns a paginated list of volunteers for event eventId.
+//   The return type always includes registered vols first (if any are needed for this page), then attended
+//   vols. Also specifies the number of registered vols in the array (see PaginatedVolunteers type). - Private
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (!req || !req.query || !req.query.eventId || !req.query.page) {

--- a/src/pages/api/events/[eventId]/volunteers.ts
+++ b/src/pages/api/events/[eventId]/volunteers.ts
@@ -1,22 +1,23 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getEventVolunteers } from "server/actions/Event";
 import errors from "utils/errors";
-import { Event, APIError } from "utils/types";
+import { Event, APIError, PaginatedVolunteers } from "utils/types";
 
 // @route   GET /api/events/[eventId]/volunteers - Returns a paginated list of volunteers for event eventId. - Private
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
-        if (!req || !req.query || !req.query.eventId) {
-            throw new Error("Need an event id for this route.");
+        if (!req || !req.query || !req.query.eventId || !req.query.page) {
+            throw new Error("Need an event id and a page number for this route.");
         }
+        const eventId = req.query.eventId as string;
+        const page = Number(req.query.page);
 
         if (req.method == "GET") {
-            const eventId = req.query.eventId as string;
-            const events: Event[] = await getEventVolunteers(eventId, 0);
+            const paginatedVols: PaginatedVolunteers = await getEventVolunteers(eventId, page);
 
             res.status(200).json({
                 success: true,
-                payload: events,
+                payload: paginatedVols,
             });
         }
     } catch (error) {

--- a/src/pages/api/events/[eventId]/volunteers.ts
+++ b/src/pages/api/events/[eventId]/volunteers.ts
@@ -13,9 +13,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
         const eventId = req.query.eventId as string;
         const page = Number(req.query.page);
+        const search = (req.query?.search as string) || "";
 
         if (req.method == "GET") {
-            const paginatedVols: PaginatedVolunteers = await getEventVolunteers(eventId, page);
+            const paginatedVols: PaginatedVolunteers = await getEventVolunteers(eventId, page, search);
 
             res.status(200).json({
                 success: true,

--- a/src/pages/api/events/[eventId]/volunteers.ts
+++ b/src/pages/api/events/[eventId]/volunteers.ts
@@ -1,2 +1,36 @@
-export {};
-// GET /api/events/[eventId]/volunteers will return a list (paginated) volunteers for event eventId
+import { NextApiRequest, NextApiResponse } from "next";
+import { getEventVolunteers } from "server/actions/Event";
+import errors from "utils/errors";
+import { Event, APIError } from "utils/types";
+
+// @route   GET /api/events/[eventId]/volunteers - Returns a paginated list of volunteers for event eventId. - Private
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        if (!req || !req.query || !req.query.eventId) {
+            throw new Error("Need an event id for this route.");
+        }
+
+        if (req.method == "GET") {
+            const eventId = req.query.eventId as string;
+            const events: Event[] = await getEventVolunteers(eventId, 0);
+
+            res.status(200).json({
+                success: true,
+                payload: events,
+            });
+        }
+    } catch (error) {
+        if (error instanceof APIError) {
+            res.status(error.statusCode).json({
+                success: false,
+                message: error.message,
+            });
+        } else {
+            console.error(error instanceof Error && error);
+            res.status(500).json({
+                success: false,
+                message: (error instanceof Error && error.message) || errors.GENERIC_ERROR,
+            });
+        }
+    }
+}

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -30,6 +30,11 @@ export interface Event {
     attendedVolunteers?: (string | Volunteer)[];
 }
 
+export interface PaginatedVolunteers {
+    volunteers: Volunteer[];
+    registeredCount: number;
+}
+
 export interface ContentfulImage {
     assetID: string;
     url: string;

--- a/utils/util.ts
+++ b/utils/util.ts
@@ -1,0 +1,4 @@
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+export function escapeRegExp(string: string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}


### PR DESCRIPTION
This PR contains the backend code for getting an event's volunteers with pagination. There are two main parts of the code:
1. Query with search
2. Query without search

The reason I had to separate these out is that MongoDB doesn't allow searching populated fields. Instead, `lookup` is used to merge the docs, then `match` is used to search. 
Since we're paginating two arrays, I look at what type of volunteer should be in the return array within each of the two main parts of code. There's 3 different scenarios here:
1. all registered vols
2. mixed vols (ret array contains both registered + attended vols) 
3. all attended vols

The final result is a new return type that guarantees that registered vols are before attended vols in an array. The number of registered vols are also specified:
```
export interface PaginatedVolunteers {
    volunteers: Volunteer[];
    registeredCount: number;
}
```