### PR TITLE
Get vol's events

### DIFF
--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -121,6 +121,10 @@ export const getEventVolunteers = async function (eventId: string, page: number,
         SORT_COND: SORT_COND,
     };
 
+    if (!eventId) {
+        throw new APIError(400, "Invalid event id.");
+    }
+
     // error check page and set it to be offset from 0 (1st page will return the 0th offset of data)
     if (isNaN(page) || page < 1) {
         throw new APIError(400, "Invalid page number");

--- a/server/actions/Event.ts
+++ b/server/actions/Event.ts
@@ -122,7 +122,7 @@ export const getEventVolunteers = async function (eventId: string, page: number,
     };
 
     // error check page and set it to be offset from 0 (1st page will return the 0th offset of data)
-    if (page < 1) {
+    if (isNaN(page) || page < 1) {
         throw new APIError(400, "Invalid page number");
     }
     page -= 1;

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -222,8 +222,8 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
  */
  export const getVolunteerEvents = async function (volId: string, page: number) {
     await mongoDB();
-    const EVENTS_PER_PAGE = 2;
-    const EVENT_FIELDS = { _id: 1, name: 1, date: 1, hours: 1 };
+    const EVENTS_PER_PAGE = 3;
+    const EVENT_FIELDS = { _id: 1, name: 1, startDate: 1, hours: 1 };
     
     if (!volId || !page) {
         throw new APIError(400, "Invalid input. Need both volunteer id and page.");
@@ -235,7 +235,7 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
     }
     page -= 1
 
-    const volunteer = await EventSchema.findById(volId).populate({
+    const volunteer = await VolunteerSchema.findById(volId).populate({
         path: "attendedEvents",
         select: EVENT_FIELDS,
         options: {

--- a/server/actions/Volunteer.ts
+++ b/server/actions/Volunteer.ts
@@ -216,26 +216,26 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
 };
 
 /**
- * This function returns a subset of a single volunteer's events. 
+ * This function returns a subset of a single volunteer's events.
  * @param volId The id of the volunteer whose events will be fetched.
  * @param page Since this data is paginated, page is used to return a certain subset of the data.
  */
- export const getVolunteerEvents = async function (volId: string, page: number) {
+export const getVolunteerEvents = async function (volId: string, page: number) {
     await mongoDB();
     const EVENTS_PER_PAGE = 3;
     const EVENT_FIELDS = { _id: 1, name: 1, startDate: 1, hours: 1 };
-    
-    if (!volId || !page) {
-        throw new APIError(400, "Invalid input. Need both volunteer id and page.");
+
+    if (!volId) {
+        throw new APIError(400, "Invalid volunteer id.");
     }
 
     // error check page and set it to be offset from 0 (1st page will return the 0th offset of data)
     if (isNaN(page) || page < 1) {
         throw new APIError(400, "Invalid page number.");
     }
-    page -= 1
+    page -= 1;
 
-    const volunteer = await VolunteerSchema.findById(volId).populate({
+    const volunteer = (await VolunteerSchema.findById(volId).populate({
         path: "attendedEvents",
         select: EVENT_FIELDS,
         options: {
@@ -243,10 +243,10 @@ export const markVolunteerNotPresent = async function (volId: string, eventId: s
             skip: page * EVENTS_PER_PAGE,
             limit: EVENTS_PER_PAGE,
         },
-    }) as Volunteer;
-    
+    })) as Volunteer;
+
     if (!volunteer) {
-        throw new APIError(404, "Volunteer not found.")
+        throw new APIError(404, "Volunteer not found.");
     }
-    return volunteer.attendedEvents as unknown as Event[];
+    return (volunteer.attendedEvents as unknown) as Event[];
 };

--- a/src/pages/api/volunteers/[volId]/events.ts
+++ b/src/pages/api/volunteers/[volId]/events.ts
@@ -1,3 +1,37 @@
-export {};
-// GET /api/volunteers/[volId]/events will return a list of paginated
-// events that volId attended/was present for
+import { NextApiRequest, NextApiResponse } from "next";
+import { getVolunteerEvents } from "server/actions/Volunteer";
+import errors from "utils/errors";
+import { Event, APIError } from "utils/types";
+
+// @route   /api/volunteers/[volId]/events - Returns a list of paginated
+// events that a single volunteer attended
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        if (req.method == "GET") {
+            if (!req || !req.query || !req.query.volId || !req.query.page) {
+                throw new Error("Need a volunteer id and a page number for this route.");
+            }
+            const volId = req.query.volId as string;
+            const page = Number(req.query.page);
+
+            const events: Event[] = await getVolunteerEvents(volId, page);
+            res.status(200).json({
+                success: true,
+                payload: events,
+            });
+        }
+    } catch (error) {
+        if (error instanceof APIError) {
+            res.status(error.statusCode).json({
+                success: false,
+                message: error.message,
+            });
+        } else {
+            console.error(error instanceof Error && error);
+            res.status(500).json({
+                success: false,
+                message: (error instanceof Error && error.message) || errors.GENERIC_ERROR,
+            });
+        }
+    }
+}

--- a/tst/server/Volunteer.test.ts
+++ b/tst/server/Volunteer.test.ts
@@ -5,6 +5,7 @@ import {
     markVolunteerNotPresent,
     markVolunteerPresent,
     registerVolunteerToEvent,
+    getVolunteerEvents,
 } from "server/actions/Volunteer";
 import VolunteerSchema from "server/models/Volunteer";
 import EventSchema from "server/models/Event";
@@ -12,7 +13,6 @@ import { Volunteer, Event } from "utils/types";
 
 jest.mock("server");
 
-// Begin getVolunteer test cases
 describe("getVolunteer() tests", () => {
     test("valid volunteer", async () => {
         const mockVol = {
@@ -68,7 +68,7 @@ describe("getVolunteers() tests", () => {
 
         await VolsMock.getVolunteers(page, search);
         expect(VolunteerSchema.find).toHaveBeenLastCalledWith(expectedFilter, expectedProjection);
-        expect(VolsMock.skip).toHaveBeenLastCalledWith(page * VOLS_PER_PAGE);
+        expect(VolsMock.skip).toHaveBeenLastCalledWith((page-1) * VOLS_PER_PAGE);
         expect(VolsMock.limit).toHaveBeenLastCalledWith(VOLS_PER_PAGE);
         /* eslint-enable */
     });
@@ -582,5 +582,85 @@ describe("markVolunteerNotPresent() tests", () => {
         expect(EventSchema.findById).toHaveBeenCalledTimes(1);
         expect(VolunteerSchema.findById).lastCalledWith(mockVolunteer._id);
         expect(VolunteerSchema.findById).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("getVolunteerEvents() tests", () => {
+    const volId = "602734007d7de15fae321153";
+
+    test("successful return", async () => {
+        const mockEvents = [
+            {
+                _id: "604d6730ca1c1d7fcd4fbdc9",
+                name: "0",
+                description: "We are sprucing in February. Come spruce with us :)",
+                caption: "It's spruce season",
+            },
+            {
+                _id: "604d6730ca1c1d7fcd4fbdc9",
+                name: "1",
+                description: "We are sprucing in February. Come spruce with us :)",
+                caption: "It's spruce season",
+            },
+            {
+                _id: "604d6730ca1c1d7fcd4fbdc9",
+                name: "2",
+                description: "We are sprucing in February. Come spruce with us :)",
+                caption: "It's spruce season",
+            },
+        ];
+
+        /* eslint-disable */
+        const VolsMock: any = {
+            getVolunteerEvents, // to be tested,
+            // findById: jest.fn(() => VolsMock),
+            populate: jest.fn(() => []),
+        };
+        VolunteerSchema.findById = jest.fn(() => VolsMock);
+        VolsMock.populate.mockImplementation(() => mockEvents); // mock final return val
+
+        const EVENTS_PER_PAGE = 3;
+        const page = 2;
+        const EVENT_FIELDS = { _id: 1, name: 1, startDate: 1, hours: 1 };
+
+        await VolsMock.getVolunteerEvents(volId, page);
+        expect(VolunteerSchema.findById).toHaveBeenLastCalledWith(volId);
+        expect(VolsMock.populate).toHaveBeenLastCalledWith({
+            path: "attendedEvents",
+            select: EVENT_FIELDS,
+            options: {
+                sort: { startDate: -1, name: 1 },
+                skip: (page-1) * EVENTS_PER_PAGE,
+                limit: EVENTS_PER_PAGE,
+            },
+        });
+        /* eslint-enable */
+    });
+
+    test("invalid page number", async () => {
+        expect.assertions(2);
+        await expect(getVolunteerEvents(volId, 0)).rejects.toThrowError("Invalid page number.");
+        await expect(getVolunteerEvents(volId, -10)).rejects.toThrowError("Invalid page number.");
+    });
+
+    test("no volunteer with that id", async () => {
+        expect.assertions(1);
+        const mockEvents = undefined;
+
+        /* eslint-disable */
+        const VolsMock: any = {
+            getVolunteerEvents, // to be tested,
+            // findById: jest.fn(() => VolsMock),
+            populate: jest.fn(() => []),
+        };
+        VolunteerSchema.findById = jest.fn(() => VolsMock);
+        VolsMock.populate.mockImplementation(() => mockEvents); // mock final return val
+
+        const EVENTS_PER_PAGE = 3;
+        const page = 2;
+        const EVENT_FIELDS = { _id: 1, name: 1, startDate: 1, hours: 1 };
+
+        await expect(VolsMock.getVolunteerEvents(volId, page)).rejects.toThrowError("Volunteer not found.");
+        /* eslint-enable */
     });
 });


### PR DESCRIPTION
This PR includes the backend for getting a volunteer's events. It returns a paginated array of all events that a volunteer attended. I tested the following endpoint: `http://localhost:3000/api/volunteers/605964095a965dee23593494/events?page=3` and added tests for the function as well. The call only returns the fields that we need for display:
```
{
    "success": true,
    "payload": [
        {
            "_id": "605ab930fecd900b30bce523",
            "startDate": "2021-03-28T03:59:00.000Z",
            "name": "k",
            "hours": 100
        },
        {
            "_id": "604ef84e83edf4aab998eb93",
            "startDate": "2021-03-15T06:01:38.000Z",
            "name": "asdasd",
            "hours": 123
        }
    ]
}
```

Let me know what you think :)