### PR TITLE
Fix event desc

### DIFF
--- a/src/components/UpsertEvent/index.tsx
+++ b/src/components/UpsertEvent/index.tsx
@@ -344,7 +344,7 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
                             />
                         </div>
                         <div style={{ margin: "10px 0px -10px 10px" }}>
-                            <Tooltip
+                            <Tooltip enterTouchDelay={0} leaveTouchDelay={5000}
                                 title="Be careful when pasting formatted text. It's recommended to 
                             clean the formatting (on the very right) and reformat it in the editor."
                             >

--- a/src/components/UpsertEvent/index.tsx
+++ b/src/components/UpsertEvent/index.tsx
@@ -323,6 +323,7 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
                                 label="Max Volunteers"
                                 type="number"
                                 value={values.maxVolunteers}
+                                helperText="Value of 0 will hide signup form."
                                 rowsMax={4}
                                 color="secondary"
                                 onChange={handleTextChange}

--- a/src/components/UpsertEvent/index.tsx
+++ b/src/components/UpsertEvent/index.tsx
@@ -19,6 +19,7 @@ import Container from "@material-ui/core/Container";
 import TextField from "@material-ui/core/TextField";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import { DateTimePicker } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
@@ -27,6 +28,7 @@ import PublishIcon from "@material-ui/icons/Publish";
 import DescriptionIcon from "@material-ui/icons/Description";
 import LocationOnIcon from "@material-ui/icons/LocationOn";
 import SubjectIcon from "@material-ui/icons/Subject";
+import InfoIcon from "@material-ui/icons/Info";
 
 interface IFormValues {
     name?: string;
@@ -340,6 +342,14 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
                                 color="secondary"
                                 onChange={handleTextChange}
                             />
+                        </div>
+                        <div style={{ margin: "10px 0px -10px 10px" }}>
+                            <Tooltip
+                                title="Be careful when pasting formatted text. It's recommended to 
+                            clean the formatting (on the very right) and reformat it in the editor."
+                            >
+                                <InfoIcon />
+                            </Tooltip>
                         </div>
                         <div className={styles.align}>
                             <DescriptionIcon style={{ fontSize: "40px", marginTop: "15px" }} />

--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -214,9 +214,19 @@ const useStyles = makeStyles((theme: Theme) =>
         cardText: {
             marginTop: "15px",
         },
+        // fix quilljs formatting
         "@global": {
             "p, ol, ul": {
                 margin: "0px",
+            },
+            ".ql-size-huge": {
+                fontSize: "1.75em",
+            },
+            ".ql-size-large": {
+                fontSize: "1.25em",
+            },
+            ".ql-size-small": {
+                fontSize: "0.75em",
             },
         },
         signUpForm: {


### PR DESCRIPTION
I noticed there were issues with quill's formatted text on an event's sign up page. I figured out it was because I copied and pasted some text from KKB's existing site and it brought the formatting over. 

To fix this, I created a tooltip to make sure the user clears any formatted text they copy over. I went ahead and also added some helper text to the maxVolunteers input field which I'll work on a later PR.

![image](https://user-images.githubusercontent.com/37582248/113599663-e7f06f00-960c-11eb-8755-1571d11e1d93.png)
![image](https://user-images.githubusercontent.com/37582248/113599637-e1fa8e00-960c-11eb-8502-4ba05ed084c6.png)

