### PR TITLE
Add event updates

### DIFF
--- a/server/models/Event.ts
+++ b/server/models/Event.ts
@@ -24,6 +24,11 @@ export const EventSchema = new Schema({
         required: true,
         default: 0,
     },
+    groupSignUp: {
+        type: Boolean,
+        required: false,
+        default: false,
+    },
     startDate: {
         type: Date,
         required: true,

--- a/src/components/UpsertEvent/index.tsx
+++ b/src/components/UpsertEvent/index.tsx
@@ -20,6 +20,8 @@ import TextField from "@material-ui/core/TextField";
 import InputAdornment from "@material-ui/core/InputAdornment";
 import Button from "@material-ui/core/Button";
 import Tooltip from "@material-ui/core/Tooltip";
+import Checkbox from "@material-ui/core/Checkbox";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
 import LinearProgress from "@material-ui/core/LinearProgress";
 import { DateTimePicker } from "@material-ui/pickers";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
@@ -38,11 +40,12 @@ interface IFormValues {
     endRegistration?: MaterialUiPickersDate | undefined;
     hours?: number;
     maxVolunteers?: number;
+    groupSignUp?: boolean;
     location?: string;
     description?: string;
     caption?: string;
     image?: File | null;
-    [key: string]: MaterialUiPickersDate | string | number | File | undefined | null;
+    [key: string]: MaterialUiPickersDate | string | number | File | boolean | undefined | null;
 }
 
 interface IErrors {
@@ -68,6 +71,7 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
         name: existingEvent?.name,
         hours: existingEvent?.hours,
         maxVolunteers: existingEvent?.maxVolunteers,
+        groupSignUp: existingEvent?.groupSignUp || false,
         location: existingEvent?.location,
         description: existingEvent?.description,
         caption: existingEvent?.caption,
@@ -101,6 +105,11 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
         setValues(values => ({ ...values, [event.target.id]: event.target.value }));
     };
 
+    // boolean state changes
+    const handleBoolChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValues(values => ({ ...values, [event.target.id]: event.target.checked }));
+    };
+
     // handle form submission, essentially just creating formdata to send
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -125,6 +134,8 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
             if (typeof values[key] === "string") {
                 fd.append(key, values[key] as string);
             } else if (typeof values[key] === "number") {
+                fd.append(key, values[key]?.toString() as string);
+            } else if (typeof values[key] === "boolean") {
                 fd.append(key, values[key]?.toString() as string);
             } else if (values[key] instanceof Date) {
                 fd.append(key, new Date(values[key] as Date).toUTCString());
@@ -313,6 +324,7 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
                                 label="Event Duration"
                                 type="number"
                                 value={values.hours}
+                                helperText="Total duration in hours."
                                 required
                                 rowsMax={4}
                                 color="secondary"
@@ -327,6 +339,20 @@ const UpsertEvent: React.FC<Props> = ({ existingEvent }) => {
                                 rowsMax={4}
                                 color="secondary"
                                 onChange={handleTextChange}
+                            />
+                        </div>
+
+                        <div style={{ margin: "0px 15px" }}>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        id="groupSignUp"
+                                        checked={values.groupSignUp}
+                                        onChange={handleBoolChange}
+                                        color="secondary"
+                                    />
+                                }
+                                label="Allow group sign ups?"
                             />
                         </div>
 

--- a/src/pages/api/events/[eventId]/index.ts
+++ b/src/pages/api/events/[eventId]/index.ts
@@ -43,9 +43,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     const newEvent: Event = (fields as unknown) as Event;
                     const file: File = files?.image as File;
 
-                    // fields are strings so convert the numbers
+                    // fields are strings so convert the numbers and booleans
                     newEvent.hours = Number(newEvent?.hours);
-                    newEvent.maxVolunteers = Number(newEvent?.maxVolunteers);
+                    newEvent.maxVolunteers = newEvent?.maxVolunteers ? Number(newEvent?.maxVolunteers) : undefined;
+                    newEvent.groupSignUp = fields["groupSignUp"] === "true";
 
                     const existingEvent = await getEvent(id);
 

--- a/src/pages/api/events/index.ts
+++ b/src/pages/api/events/index.ts
@@ -53,7 +53,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
                     // fields are strings so convert the numbers
                     event.hours = Number(event?.hours);
-                    event.maxVolunteers = Number(event?.maxVolunteers);
+                    event.maxVolunteers = event?.maxVolunteers ? Number(event?.maxVolunteers) : undefined;
+                    event.groupSignUp = fields["groupSignUp"] === "true";
 
                     if (file) {
                         if (file?.size > constants.contentfulImageLimit) {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -5,7 +5,6 @@ export interface Volunteer {
     email?: string;
     name: string;
     phone?: string;
-    // filledForm?: boolean;
     totalEvents?: number; // num attended events
     totalHours?: number; // aggregate of attended event hours
     registeredEvents?: (string | Event)[]; // objectid ref is a string
@@ -20,6 +19,7 @@ export interface Event {
     maxVolunteers?: number;
     volunteerCount?: number; // registered + attended
     location?: string;
+    groupSignUp?: boolean;
     startDate?: Date;
     endDate?: Date;
     startRegistration?: Date;


### PR DESCRIPTION
 Minor update to the event type and schema: I added a `groupSignUp` boolean to mark whether the event will allow group sign ups. I changed the frontend to include a checkbox for it and also updates the `update event` / `new event` apis to handle this type.

![Screen Shot 2021-04-05 at 9 10 24 PM](https://user-images.githubusercontent.com/37582248/113647256-7dfdb700-9658-11eb-9cac-5e007ca0c9dd.png)
