### PR TITLE
Update volunteer page frontend

### DIFF
--- a/src/components/VolunteerEventsList/index.tsx
+++ b/src/components/VolunteerEventsList/index.tsx
@@ -103,7 +103,11 @@ const VolunteerEventsList = (vol: Volunteer) => {
                                 </TableCell>
                                 <TableCell align="center">
                                     <CoreTypography variant="body2">
-                                        {row.startDate?.toString().split("T")[0]}
+                                        {new Date(row.startDate || "").toLocaleDateString("en-US", {
+                                            month: "2-digit",
+                                            day: "2-digit",
+                                            year: "numeric",
+                                        })}
                                     </CoreTypography>
                                 </TableCell>
                                 <TableCell align="center">

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -99,7 +99,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                         </button>
                     </div>
                 </Paper>
-                <VolunteerEventsList {...vol} />
+                {vol._id !== undefined && <VolunteerEventsList {...{ volId: vol._id, attendedEvents: [] }} />}
             </div>
         </>
     );
@@ -235,7 +235,7 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         hoursVerificationButton: {
             color: colors.white,
-            backgroundColor: colors.pink,
+            backgroundColor: colors.orange,
             border: "none",
             padding: "0 8px",
             borderRadius: "10px",

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import VolunteerEventsList from "../../../../components/VolunteerEventsList";
 import { getVolunteer } from "server/actions/Volunteer";
 import { Volunteer } from "utils/types";
@@ -23,6 +23,7 @@ interface Props {
 const VolunteerPage: NextPage<Props> = ({ vol }) => {
     const classes = useStyles();
     const router = useRouter();
+    const [emailSuccess, setEmailSuccess] = useState<boolean>(false);
 
     if (!vol) {
         return <Error statusCode={404} />;
@@ -39,7 +40,10 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
     const handleSendVerificationEmail = async () => {
         try {
             if (vol._id) {
-                await fetch(`${urls.api.volunteers}/${vol._id}/email`, { method: "PUT" });
+                const res = await fetch(`${urls.api.volunteers}/${vol._id}/email`, { method: "PUT" });
+                if (res.status === 200) {
+                    setEmailSuccess(true);
+                }
             }
         } catch (error) {
             console.log(error);
@@ -104,7 +108,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                         <button className={classes.hoursVerificationButton} onClick={handleSendVerificationEmail}>
                             <CoreTypography variant="body2">
                                 <EmailIcon fontSize="large" style={{ verticalAlign: "middle" }} />
-                                &nbsp;&nbsp;Total Hours Verification
+                                &nbsp;&nbsp;{emailSuccess ? "Verification Sent!" : "Total Hours Verification"}
                             </CoreTypography>
                         </button>
                     </div>
@@ -252,6 +256,9 @@ const useStyles = makeStyles((theme: Theme) =>
             [theme.breakpoints.between(0, "sm")]: {
                 padding: "0 4px",
             },
+            "&:active": {
+                transform: "scale(0.75)",
+            },
         },
         navIcon: {
             border: "none",
@@ -259,7 +266,7 @@ const useStyles = makeStyles((theme: Theme) =>
             outline: "none",
             verticalAlign: "top",
             "&:active": {
-                transform: "scale(0.75)",
+                transform: "scale(0.95)",
             },
         },
     })

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -49,14 +49,13 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
             console.log(error);
         }
     };
-
     return (
         <>
             <div className={classes.container}>
                 <div className={classes.volInfoContainer}>
                     <Paper className={classes.nameCard} elevation={2}>
                         <div className={classes.nameCardContent}>
-                            <CoreTypography variant="body1" style={{ fontSize: "60px" }}>
+                            <CoreTypography variant={vol.name.length < 15 ? "h1" : "h2"}>
                                 <div className={classes.nameCardTopRow}>
                                     {vol.name}
                                     <div>
@@ -102,9 +101,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                 </div>
                 <Paper className={classes.nameHeader} elevation={0}>
                     <div className={classes.nameHeaderContent}>
-                        <CoreTypography variant="body1" style={{ fontSize: "35px" }}>
-                            {firstName}&apos;s Events
-                        </CoreTypography>
+                        <CoreTypography variant="h2">{firstName}&apos;s Events</CoreTypography>
                         <button className={classes.hoursVerificationButton} onClick={handleSendVerificationEmail}>
                             <CoreTypography variant="body2">
                                 <EmailIcon fontSize="large" style={{ verticalAlign: "middle" }} />
@@ -162,32 +159,34 @@ const useStyles = makeStyles((theme: Theme) =>
             display: "flex",
             flexDirection: "row",
             alignItems: "center",
-            marginTop: "40px",
             justifyContent: "space-between",
-            width: "100%",
+            width: "90vw",
             [theme.breakpoints.between(0, "sm")]: {
                 flexDirection: "column",
-                width: "100%",
             },
         },
         volInfoRight: {
             display: "flex",
             alignItems: "center",
-            justifyContent: "space-between",
+            justifyContent: "space-evenly",
             [theme.breakpoints.between(0, "sm")]: {
                 marginTop: "20px",
-                width: "90%",
+                width: "90vw",
             },
         },
         nameCard: {
             border: `1px solid ${theme.palette.primary.light}`,
-            [theme.breakpoints.between(0, "sm")]: {
-                width: "90%",
-            },
             "&>*": {
                 margin: theme.spacing(1),
                 width: theme.spacing(65),
                 height: theme.spacing(30),
+            },
+            [theme.breakpoints.between(0, "sm")]: {
+                width: "90vw",
+                "&>*": {
+                    width: "90vw",
+                    height: theme.spacing(25),
+                },
             },
         },
         nameCardContent: {
@@ -198,6 +197,9 @@ const useStyles = makeStyles((theme: Theme) =>
             flexDirection: "column",
             alignItems: "left",
             justifyContent: "space-between",
+            [theme.breakpoints.between(0, "sm")]: {
+                paddingLeft: "10px",
+            },
         },
         nameCardTopRow: {
             width: "100%",
@@ -205,7 +207,8 @@ const useStyles = makeStyles((theme: Theme) =>
             flexDirection: "row",
             justifyContent: "space-between",
             [theme.breakpoints.between(0, "sm")]: {
-                width: "90%",
+                width: "100%",
+                paddingRight: "5px",
             },
         },
         nameCardIcons: {
@@ -214,13 +217,18 @@ const useStyles = makeStyles((theme: Theme) =>
         rightCards: {
             marginLeft: "40px",
             border: `1px solid ${theme.palette.primary.light}`,
-            [theme.breakpoints.between(0, "sm")]: {
-                marginLeft: "0px",
-            },
             "&>*": {
                 margin: theme.spacing(1),
                 width: theme.spacing(27),
                 height: theme.spacing(30),
+            },
+            [theme.breakpoints.between(0, "sm")]: {
+                marginLeft: "0px",
+                "&>*": {
+                    margin: theme.spacing(1),
+                    width: "40vw",
+                    height: theme.spacing(30),
+                },
             },
         },
         rightCardsContent: {
@@ -230,14 +238,19 @@ const useStyles = makeStyles((theme: Theme) =>
             border: `1px solid ${theme.palette.primary.light}`,
             marginTop: "50px",
             marginBottom: "30px",
-            width: "100%",
+            width: "90vw",
             "&>*": {
                 width: "100%",
                 margin: theme.spacing(1),
                 height: theme.spacing(7),
             },
             [theme.breakpoints.between(0, "sm")]: {
-                width: "90%",
+                width: "90vw",
+                "&>*": {
+                    width: "100%",
+                    margin: theme.spacing(3),
+                    height: theme.spacing(10),
+                },
             },
         },
         nameHeaderContent: {
@@ -246,6 +259,9 @@ const useStyles = makeStyles((theme: Theme) =>
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
+            [theme.breakpoints.between(0, "sm")]: {
+                flexDirection: "column",
+            },
         },
         hoursVerificationButton: {
             color: colors.white,

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -3,7 +3,7 @@ import VolunteerEventsList from "../../../../components/VolunteerEventsList";
 import { getVolunteer } from "server/actions/Volunteer";
 import { Volunteer } from "utils/types";
 import { GetStaticPropsContext, NextPage } from "next";
-import { Router, useRouter } from "next/router";
+import { useRouter } from "next/router";
 import Error from "next/error";
 import constants from "utils/constants";
 import urls from "utils/urls";
@@ -33,6 +33,16 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
     const handleEditClick = async () => {
         if (vol._id) {
             await router.push(urls.pages.updateVolunteer(vol._id));
+        }
+    };
+
+    const handleSendVerificationEmail = async () => {
+        try {
+            if (vol._id) {
+                await fetch(`${urls.api.volunteers}/${vol._id}/email`, { method: "PUT" });
+            }
+        } catch (error) {
+            console.log(error);
         }
     };
 
@@ -91,7 +101,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                         <CoreTypography variant="body1" style={{ fontSize: "35px" }}>
                             {firstName}&apos;s Events
                         </CoreTypography>
-                        <button className={classes.hoursVerificationButton}>
+                        <button className={classes.hoursVerificationButton} onClick={handleSendVerificationEmail}>
                             <CoreTypography variant="body2">
                                 <EmailIcon fontSize="large" style={{ verticalAlign: "middle" }} />
                                 &nbsp;&nbsp;Total Hours Verification

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -247,7 +247,7 @@ const useStyles = makeStyles((theme: Theme) =>
             color: colors.white,
             backgroundColor: colors.orange,
             border: "none",
-            padding: "0 8px",
+            padding: "4px 10px",
             borderRadius: "10px",
             [theme.breakpoints.between(0, "sm")]: {
                 padding: "0 4px",

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -99,7 +99,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                         </button>
                     </div>
                 </Paper>
-                {vol._id !== undefined && <VolunteerEventsList {...{ volId: vol._id, attendedEvents: [] }} />}
+                <VolunteerEventsList {...vol} />
             </div>
         </>
     );


### PR DESCRIPTION
This PR updates the volunteer profile page's attended events table to use the backend pagination. The number of events displayed per page is determined in the backend. If this number changes, the styling of this table -- the arrows at the bottom -- will need to be modified to ensure correct spacing in the display. The pagination arrows are responsive to whether the prev/next pages are available to click. I also added on click functionality to the send email button which uses the api route `api/admin/volunteers/[volId]/email` to send a verification email to the user. I tested the button with my mock account and received an email instantly. 

Here are some screenshots of the new table
<img width="1280" alt="Screen Shot 2021-04-20 at 4 17 14 PM" src="https://user-images.githubusercontent.com/58822572/115459800-73fdbb80-a1f5-11eb-8319-b029044da822.png">
<img width="1280" alt="Screen Shot 2021-04-20 at 4 17 38 PM" src="https://user-images.githubusercontent.com/58822572/115459813-7829d900-a1f5-11eb-8c92-48c64a7488b7.png">
<img width="1280" alt="Screen Shot 2021-04-20 at 4 17 44 PM" src="https://user-images.githubusercontent.com/58822572/115459829-7f50e700-a1f5-11eb-9613-9208a1fbf653.png">

