### PR TITLE
Shade past events + misc changes

### DIFF
--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -28,6 +28,7 @@ import colors from "src/components/core/colors";
 interface Props {
     event: Event;
     isAdmin?: boolean;
+    pastEvent: boolean;
 }
 
 interface ThumbProps {
@@ -35,7 +36,7 @@ interface ThumbProps {
     children: ReactNode;
 }
 
-const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
+const EventCard: React.FC<Props> = ({ event, isAdmin = false, pastEvent }) => {
     const classes = useStyles();
     const router = useRouter();
 
@@ -82,7 +83,7 @@ const EventCard: React.FC<Props> = ({ event, isAdmin = false }) => {
 
         return (
             <div
-                className={`${classes.thumbnailPlaceholder}`}
+                className={`${classes.thumbnailPlaceholder} ${pastEvent ? classes.pastEvent : ""}`}
                 id="eventThumb"
                 style={
                     hasImage
@@ -234,6 +235,9 @@ const useStyles = makeStyles((theme: Theme) =>
             height: 200,
             transition: ".3s",
             width: "100%",
+        },
+        pastEvent: {
+            filter: "grayscale(100%)",
         },
         hidden: {
             opacity: 0,

--- a/src/components/EventSignUp/index.tsx
+++ b/src/components/EventSignUp/index.tsx
@@ -160,7 +160,7 @@ const EventSignUp: React.FC<Props> = ({ id, groupSignUp }) => {
                 <Container className={styles.donateWrapper}>
                     <CoreTypography variant="h4">Can&apos;t volunteer?</CoreTypography>
                     <a
-                        href="http://www.keepknoxvillebeautiful.org/donate"
+                        href={constants.org.donateLink}
                         target="_blank"
                         rel="noreferrer"
                         style={{ textDecoration: "none" }}

--- a/src/components/EventsContainer/index.tsx
+++ b/src/components/EventsContainer/index.tsx
@@ -7,6 +7,7 @@ import { Event } from "utils/types";
 
 interface Props {
     events: Event[];
+    pastEvents: boolean;
 }
 
 export default function EventsContainer(props: Props) {
@@ -19,7 +20,7 @@ export default function EventsContainer(props: Props) {
                     {props.events.map((event: Event, i: number) => {
                         return (
                             <Grid item xs={12} sm={8} md={5} lg={4} key={i}>
-                                <EventCard event={event} />
+                                <EventCard event={event} pastEvent={props.pastEvents} />
                             </Grid>
                         );
                     })}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -65,7 +65,7 @@ const Home: NextPage<Props> = ({ currentEvents, pastEvents, width }) => {
                 </Grid>
             </div>
             <Container disableGutters style={{ marginTop: "-20vh" }}>
-                <EventsContainer events={currentEvents} />
+                <EventsContainer events={currentEvents} pastEvents={false} />
             </Container>
 
             <Container disableGutters maxWidth="lg">
@@ -76,7 +76,7 @@ const Home: NextPage<Props> = ({ currentEvents, pastEvents, width }) => {
             </Container>
 
             <Container disableGutters style={{ marginTop: "0vh", marginBottom: "100px" }}>
-                <EventsContainer events={pastEvents} />
+                <EventsContainer events={pastEvents} pastEvents={true} />
             </Container>
         </div>
     );

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -115,7 +115,6 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         form: {
             paddingTop: "20px",
-
             width: "350px",
             display: "inherit",
             flexDirection: "inherit",
@@ -130,6 +129,7 @@ const useStyles = makeStyles((theme: Theme) =>
             height: "40px",
             fontSize: "17px",
             borderStyle: "solid",
+            borderWidth: "1px",
             textIndent: "35px",
             marginBottom: "15px",
             "&:focus": {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -15,6 +15,7 @@ export default {
             phone: "(865) 521-6957",
             email: "info@Keepknoxvillebeautiful.org",
         },
+        donateLink: "http://www.keepknoxvillebeautiful.org/donate",
     },
     revalidate: {
         upcomingEvents: 20,


### PR DESCRIPTION
Super simple - past event images are grayscaled so users can tell that they have passed.
Edit: Also added donate url to constants
Edit: Reduced login input border width to 1px to be consistent with the event signup component

![image](https://user-images.githubusercontent.com/71574118/116140235-0a722700-a6a5-11eb-928d-ead235c9123d.png)
