### PR TITLE
Add auth and login checks for all endpoints and admin pages

### DIFF
--- a/src/pages/admin/events/new.tsx
+++ b/src/pages/admin/events/new.tsx
@@ -1,9 +1,32 @@
 import React from "react";
-import { NextPage } from "next";
+import { NextPage, NextPageContext } from "next";
 import UpsertEvent from "src/components/UpsertEvent";
+import urls from "utils/urls";
 
 const AddEventPage: NextPage = () => {
     return <UpsertEvent />;
 };
 
+// validate valid admin user
+export async function getServerSideProps(context: NextPageContext) {
+    try {
+        const cookie = context.req?.headers.cookie;
+        const response = await fetch(`${urls.baseUrl}${urls.api.validateLogin}`, {
+            method: "POST",
+            headers: {
+                cookie: cookie || "",
+            },
+        });
+
+        // redirect
+        if (response.status !== 200) {
+            context.res?.writeHead(302, {
+                Location: urls.pages.login,
+            });
+            context.res?.end();
+        }
+    } catch (error) {
+        console.log(error);
+    }
+}
 export default AddEventPage;

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import VolunteerEventsList from "../../../../components/VolunteerEventsList";
 import { getVolunteer } from "server/actions/Volunteer";
 import { Volunteer } from "utils/types";
-import { GetStaticPropsContext, NextPage } from "next";
+import { GetStaticPropsContext, NextPage, NextPageContext } from "next";
 import { Router, useRouter } from "next/router";
 import Error from "next/error";
 import constants from "utils/constants";
@@ -104,7 +104,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
         </>
     );
 };
-
+/*
 // get volunteer data
 export async function getStaticProps(context: GetStaticPropsContext) {
     try {
@@ -122,8 +122,8 @@ export async function getStaticProps(context: GetStaticPropsContext) {
             revalidate: constants.revalidate.volunteerProfile,
         };
     }
-}
-
+*/
+/*
 // required for dynamic pages: prerender volunteers at build time
 export async function getStaticPaths() {
     const volunteers: Volunteer[] = []; //await getVolunteers({});
@@ -133,6 +133,46 @@ export async function getStaticPaths() {
     }));
 
     return { paths, fallback: true };
+}
+*/
+// validate valid admin user
+export async function getServerSideProps(context: NextPageContext) {
+    try {
+        const cookie = context.req?.headers.cookie;
+        const response = await fetch(`${urls.baseUrl}${urls.api.validateLogin}`, {
+            method: "POST",
+            headers: {
+                cookie: cookie || "",
+            },
+        });
+
+        // redirect
+        if (response.status !== 200) {
+            context.res?.writeHead(302, {
+                Location: urls.pages.login,
+            });
+            context.res?.end();
+        }
+
+        const { volId } = context.query;
+        const vol: Volunteer = await getVolunteer(volId as string);
+
+        const volunteers: Volunteer[] = []; //await getVolunteers({});
+        const paths = volunteers.map(volunteer => ({
+            params: { name: volunteer._id },
+        }));
+
+        return {
+            props: {
+                vol: JSON.parse(JSON.stringify(vol)) as Volunteer,
+            },
+            //revalidate: constants.revalidate.volunteerProfile,
+            //paths,
+            //fallback: true,
+        };
+    } catch (error) {
+        console.log(error);
+    }
 }
 
 const useStyles = makeStyles((theme: Theme) =>

--- a/src/pages/admin/volunteers/[volId]/update.tsx
+++ b/src/pages/admin/volunteers/[volId]/update.tsx
@@ -4,6 +4,7 @@ import Router from "next/router";
 import { Volunteer } from "utils/types";
 import UpdateVolunteer from "src/components/UpdateVolunteer";
 import { getVolunteer } from "server/actions/Volunteer";
+import urls from "utils/urls";
 
 interface Props {
     vol: Volunteer;
@@ -14,17 +15,38 @@ const UpdateEventPage: NextPage<Props> = ({ vol }) => {
 };
 
 export async function getServerSideProps(context: NextPageContext) {
-    // get eventId from url by using context
-    const volId = context.query.volId as string;
+    try {
+        // validate valid admin user
+        const cookie = context.req?.headers.cookie;
+        const response = await fetch(`${urls.baseUrl}${urls.api.validateLogin}`, {
+            method: "POST",
+            headers: {
+                cookie: cookie || "",
+            },
+        });
 
-    // this func is run on server-side, so we can safely fetch the volunteer directly
-    const vol: Volunteer = await getVolunteer(volId);
+        // redirect
+        if (response.status !== 200) {
+            context.res?.writeHead(302, {
+                Location: urls.pages.login,
+            });
+            context.res?.end();
+        }
 
-    return {
-        props: {
-            vol: JSON.parse(JSON.stringify(vol)) as Volunteer,
-        },
-    };
+        // get eventId from url by using context
+        const volId = context.query.volId as string;
+
+        // this func is run on server-side, so we can safely fetch the volunteer directly
+        const vol: Volunteer = await getVolunteer(volId);
+
+        return {
+            props: {
+                vol: JSON.parse(JSON.stringify(vol)) as Volunteer,
+            },
+        };
+    } catch (error) {
+        console.log(error);
+    }
 }
 
 export default UpdateEventPage;

--- a/src/pages/api/events/[eventId]/index.ts
+++ b/src/pages/api/events/[eventId]/index.ts
@@ -6,6 +6,7 @@ import { Event, APIError } from "utils/types";
 import constants from "utils/constants";
 import formidable, { File } from "formidable";
 import { deleteAssetByID, uploadImage } from "server/actions/Contentful";
+import authenticate from "server/actions/Authenticate";
 
 // formidable config
 export const config = {
@@ -31,11 +32,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 payload: event,
             });
         } else if (req.method === "DELETE") {
+            authenticate(req, res);
             await deleteEvent(id);
             res.status(200).json({
                 success: true,
             });
         } else if (req.method === "POST") {
+            authenticate(req, res);
             const form = new formidable.IncomingForm();
             form.parse(req, async (err: string, fields: formidable.Fields, files: formidable.Files) => {
                 try {

--- a/src/pages/api/events/[eventId]/notPresent/[volid].ts
+++ b/src/pages/api/events/[eventId]/notPresent/[volid].ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import authenticate from "server/actions/Authenticate";
 import { markVolunteerNotPresent } from "server/actions/Volunteer";
 import errors from "utils/errors";
 import { APIError } from "utils/types";
@@ -11,6 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
 
         if (req.method == "POST") {
+            authenticate(req, res);
             const eventId = req.query.eventId as string;
             const volId = req.query.volId as string;
 

--- a/src/pages/api/events/[eventId]/present/[volId].ts
+++ b/src/pages/api/events/[eventId]/present/[volId].ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import authenticate from "server/actions/Authenticate";
 import { markVolunteerPresent } from "server/actions/Volunteer";
 import errors from "utils/errors";
 import { APIError } from "utils/types";
@@ -11,6 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
 
         if (req.method == "POST") {
+            authenticate(req, res);
             const eventId = req.query.eventId as string;
             const volId = req.query.volId as string;
 

--- a/src/pages/api/events/[eventId]/volunteers.ts
+++ b/src/pages/api/events/[eventId]/volunteers.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getEventVolunteers } from "server/actions/Event";
 import errors from "utils/errors";
 import { Event, APIError, PaginatedVolunteers } from "utils/types";
+import authenticate from "server/actions/Authenticate";
 
 // @route   GET /api/events/[eventId]/volunteers - Returns a paginated list of volunteers for event eventId.
 //   The return type always includes registered vols first (if any are needed for this page), then attended
@@ -16,6 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const search = (req.query?.search as string) || "";
 
         if (req.method == "GET") {
+            authenticate(req, res);
             const paginatedVols: PaginatedVolunteers = await getEventVolunteers(eventId, page, search);
 
             res.status(200).json({

--- a/src/pages/api/volunteers/[volId]/email.ts
+++ b/src/pages/api/volunteers/[volId]/email.ts
@@ -2,12 +2,14 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { sendVerificationEmail } from "server/actions/Volunteer";
 import errors from "utils/errors";
 import { Volunteer, APIError } from "utils/types";
+import authenticate from "server/actions/Authenticate";
 
 // @route   PUT /api/volunteers/[volId]/email - Emails a single volunteer
 //   their attendance information. - Private
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (req.method === "PUT") {
+            authenticate(req, res);
             if (!req || !req.query || !req.query.volId) {
                 throw new Error("Need a volunteer id for this route.");
             }

--- a/src/pages/api/volunteers/[volId]/events.ts
+++ b/src/pages/api/volunteers/[volId]/events.ts
@@ -2,12 +2,14 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getVolunteerEvents } from "server/actions/Volunteer";
 import errors from "utils/errors";
 import { Event, APIError } from "utils/types";
+import authenticate from "server/actions/Authenticate";
 
 // @route   /api/volunteers/[volId]/events - Returns a list of paginated
 //   events that a single volunteer attended. - Private.
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (req.method == "GET") {
+            authenticate(req, res);
             if (!req || !req.query || !req.query.volId || !req.query.page) {
                 throw new Error("Need a volunteer id and a page number for this route.");
             }

--- a/src/pages/api/volunteers/[volId]/index.ts
+++ b/src/pages/api/volunteers/[volId]/index.ts
@@ -4,6 +4,7 @@ import errors from "utils/errors";
 import { Volunteer, APIError } from "utils/types";
 import constants from "utils/constants";
 import formidable from "formidable";
+import authenticate from "server/actions/Authenticate";
 
 // formidable config
 export const config = {
@@ -23,12 +24,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const id = req.query.volId as string;
 
         if (req.method == "GET") {
+            authenticate(req, res);
             const vol: Volunteer = await getVolunteer(id);
             res.status(200).json({
                 success: true,
                 payload: vol,
             });
         } else if (req.method == "POST") {
+            authenticate(req, res);
             const form = new formidable.IncomingForm();
             form.parse(req, async (err: string, fields: formidable.Fields, files: formidable.Files) => {
                 try {

--- a/src/pages/api/volunteers/index.ts
+++ b/src/pages/api/volunteers/index.ts
@@ -3,6 +3,7 @@ import errors from "utils/errors";
 import formidable from "formidable";
 import { Volunteer, APIError, LoadMorePaginatedData } from "utils/types";
 import { addVolunteer, getVolunteers } from "server/actions/Volunteer";
+import authenticate from "server/actions/Authenticate";
 
 // formidable config
 export const config = {
@@ -16,6 +17,7 @@ export const config = {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
         if (req.method === "GET") {
+            authenticate(req, res);
             const page: number = parseInt(req.query?.page as string);
             const search = req.query?.search as string;
             const volunteerData: LoadMorePaginatedData = await getVolunteers(page, search);


### PR DESCRIPTION
This PR adds login check to all admin pages and authentication check to each protected api route. I tested each private route with Postman and was denied access if not logged in, allowed if logged in. Some potentially major changes (from `getStaticProps` to `getServerSideProps`) on the `/admin/volunteers/index` and `/admin/volunteers/[volId]/index` pages to allow for redirection and login validation. Not sure if this is the best way to do this, so I would appreciate some feedback on those pages! I only commented out the original until I know if the changes on these pages are acceptable. 