### PR TITLE
Updating mobile responsiveness on vol profile page

### DIFF
--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -101,7 +101,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                 </div>
                 <Paper className={classes.nameHeader} elevation={0}>
                     <div className={classes.nameHeaderContent}>
-                        <CoreTypography variant="h2">{/*firstName*/}HarryPotterLongName&apos;s Events</CoreTypography>
+                        <CoreTypography variant="h2">{firstName}&apos;s Events</CoreTypography>
                         <button className={classes.hoursVerificationButton} onClick={handleSendVerificationEmail}>
                             <CoreTypography variant="body2">
                                 <EmailIcon fontSize="large" style={{ verticalAlign: "middle" }} />

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -115,37 +115,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
         </>
     );
 };
-/*
-// get volunteer data
-export async function getStaticProps(context: GetStaticPropsContext) {
-    try {
-        const vol: Volunteer = await getVolunteer(context.params?.volId as string);
 
-        return {
-            props: {
-                vol: JSON.parse(JSON.stringify(vol)) as Volunteer,
-            },
-            revalidate: constants.revalidate.volunteerProfile,
-        };
-    } catch (error) {
-        return {
-            props: {},
-            revalidate: constants.revalidate.volunteerProfile,
-        };
-    }
-*/
-/*
-// required for dynamic pages: prerender volunteers at build time
-export async function getStaticPaths() {
-    const volunteers: Volunteer[] = []; //await getVolunteers({});
-
-    const paths = volunteers.map(volunteer => ({
-        params: { name: volunteer._id },
-    }));
-
-    return { paths, fallback: true };
-}
-*/
 // validate valid admin user
 export async function getServerSideProps(context: NextPageContext) {
     try {
@@ -209,6 +179,7 @@ const useStyles = makeStyles((theme: Theme) =>
             alignItems: "center",
             justifyContent: "space-evenly",
             [theme.breakpoints.between(0, "sm")]: {
+                justifyContent: "space-between",
                 marginTop: "20px",
                 width: "90vw",
             },
@@ -299,6 +270,8 @@ const useStyles = makeStyles((theme: Theme) =>
             alignItems: "center",
             justifyContent: "space-between",
             [theme.breakpoints.between(0, "sm")]: {
+                paddingLeft: "0",
+                paddingRight: "35px",
                 flexDirection: "column",
             },
         },

--- a/src/pages/admin/volunteers/[volId]/index.tsx
+++ b/src/pages/admin/volunteers/[volId]/index.tsx
@@ -83,7 +83,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                     <div className={classes.volInfoRight}>
                         <Paper className={classes.rightCards} elevation={2}>
                             <div className={classes.rightCardsContent}>
-                                <CoreTypography variant="body1" style={{ fontSize: "130px" }}>
+                                <CoreTypography className={classes.rightCardFont} variant="body1">
                                     {vol.totalEvents == undefined ? 0 : vol.totalEvents}
                                 </CoreTypography>
                                 <CoreTypography variant="body1">Events Attended</CoreTypography>
@@ -91,7 +91,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                         </Paper>
                         <Paper className={classes.rightCards} elevation={2}>
                             <div className={classes.rightCardsContent}>
-                                <CoreTypography variant="body1" style={{ fontSize: "130px" }}>
+                                <CoreTypography className={classes.rightCardFont} variant="body1">
                                     {vol.totalHours == undefined ? 0 : vol.totalHours}
                                 </CoreTypography>
                                 <CoreTypography variant="body1">Total Hours</CoreTypography>
@@ -101,7 +101,7 @@ const VolunteerPage: NextPage<Props> = ({ vol }) => {
                 </div>
                 <Paper className={classes.nameHeader} elevation={0}>
                     <div className={classes.nameHeaderContent}>
-                        <CoreTypography variant="h2">{firstName}&apos;s Events</CoreTypography>
+                        <CoreTypography variant="h2">{/*firstName*/}HarryPotterLongName&apos;s Events</CoreTypography>
                         <button className={classes.hoursVerificationButton} onClick={handleSendVerificationEmail}>
                             <CoreTypography variant="body2">
                                 <EmailIcon fontSize="large" style={{ verticalAlign: "middle" }} />
@@ -237,12 +237,18 @@ const useStyles = makeStyles((theme: Theme) =>
                 "&>*": {
                     margin: theme.spacing(1),
                     width: "40vw",
-                    height: theme.spacing(30),
+                    height: theme.spacing(20),
                 },
             },
         },
         rightCardsContent: {
             textAlign: "center",
+        },
+        rightCardFont: {
+            fontSize: "130px",
+            [theme.breakpoints.between(0, "sm")]: {
+                fontSize: "75px",
+            },
         },
         nameHeader: {
             border: `1px solid ${theme.palette.primary.light}`,
@@ -256,10 +262,11 @@ const useStyles = makeStyles((theme: Theme) =>
             },
             [theme.breakpoints.between(0, "sm")]: {
                 width: "90vw",
+                marginTop: "35px",
                 "&>*": {
                     width: "100%",
                     margin: theme.spacing(3),
-                    height: theme.spacing(10),
+                    height: theme.spacing(12),
                 },
             },
         },
@@ -273,6 +280,7 @@ const useStyles = makeStyles((theme: Theme) =>
                 paddingLeft: "0",
                 paddingRight: "35px",
                 flexDirection: "column",
+                justifyContent: "space-between",
             },
         },
         hoursVerificationButton: {
@@ -282,7 +290,7 @@ const useStyles = makeStyles((theme: Theme) =>
             padding: "4px 10px",
             borderRadius: "10px",
             [theme.breakpoints.between(0, "sm")]: {
-                padding: "0 4px",
+                padding: "4px 10px",
             },
             "&:active": {
                 transform: "scale(0.75)",


### PR DESCRIPTION
This PR addresses the issues that Selena pointed out of centering the name header content and adding responsiveness to allow 3 digit numbers to fit into the total hours and attended events boxes. They are pretty basic changes, but I think they make the page look more polished. 

Some screenshots of the changes:
![image](https://user-images.githubusercontent.com/58822572/118735693-f1c1e080-b80e-11eb-9ec5-478735b83aff.png)
![image](https://user-images.githubusercontent.com/58822572/118735727-00a89300-b80f-11eb-96d8-29ec1a84c64f.png)
