### PR TITLE
Date error checking + update/add distinction

### DIFF
--- a/src/pages/events/[eventId].tsx
+++ b/src/pages/events/[eventId].tsx
@@ -38,6 +38,7 @@ const EventPage: NextPage<Props> = ({ event }) => {
                         backgroundColor: theme.palette.secondary.main,
                         width: "90%",
                         height: "30%",
+                        minHeight: "250px",
                     }}
                 >
                     <img


### PR DESCRIPTION
Includes changes to the things that @andlrutt pointed out.

When the user is editing an event (rather than adding a new one):
![image](https://user-images.githubusercontent.com/37582248/119392212-1990c880-bc95-11eb-9773-813699359367.png)

When there's errors on the start/registration dates:
![image](https://user-images.githubusercontent.com/37582248/119392239-21506d00-bc95-11eb-899d-89f24ebc0880.png)

